### PR TITLE
The Appdata files now go to /usr/share/metainfo

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -19,7 +19,7 @@ appstream_file = i18n.merge_file(
 	output: 'com.github.maoschanz.drawing.appdata.xml',
 	po_dir: '../po',
 	install: true,
-	install_dir: join_paths(get_option('datadir'), 'appdata')
+	install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
From
  `/usr/share/appdata/%{id}.appdata.xml`
to
 `/usr/share/metainfo/%{id}.appdata.xml`

https://www.freedesktop.org/software/appstream/docs/chap-Quickstart.html#sect-Quickstart-DesktopApps