### PR TITLE
Require meson version >= 0.50

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
 	'drawing',
 	version: '0.3.0',
-	meson_version: '>= 0.48.0',
+	meson_version: '>= 0.50.0',
 )
 
 i18n = import('i18n')


### PR DESCRIPTION
Otherwise you get warnings like this:

`WARNING: Project targetting '>= 0.48.0' but tried to use feature introduced in '0.50.0': install arg in configure_file`