### PR TITLE
Update Fedora installation instructions & more

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ You can install it from flathub.org using the instructions on [this page](https:
 
 - Debian: the package is provided [here](https://github.com/maoschanz/drawing/releases)
 
->**Warning:** I don't maintain the following packages, and thus I don't know what versions they provide.
+>**Warning:** I don't maintain the following packages.
 
-- Fedora (29, 30 and Rawhide) ([COPR](https://copr.fedorainfracloud.org/coprs/atim/drawing/))
+- [Fedora](https://apps.fedoraproject.org/packages/drawing) (29, 30 and Rawhide): `sudo dnf install drawing`
 - Arch and Manjaro ([AUR](https://aur.archlinux.org/packages/drawing-git/))
 
 <!-- TODO Solus -->
@@ -115,3 +115,4 @@ You can install it from flathub.org using the instructions on [this page](https:
 
 [See here](./INSTALL_FROM_SOURCE.md)
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/drawing.svg)](https://repology.org/project/drawing/versions)


### PR DESCRIPTION
Drawing is already for a long time in official Fedora repos, not COPR. And latest version already [on QA](https://bodhi.fedoraproject.org/updates/FEDORA-2019-02ce9dd16f).

Plus cool packaging status monitor for all distros. :) Everyone can see which version available now in real time.

