### PR TITLE
Update de_DE.po

### DIFF
--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: drawing\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-07-25 20:40+0200\n"
-"PO-Revision-Date: 2019-08-02 11:02+0200\n"
+"PO-Revision-Date: 2019-08-03 13:53+0200\n"
 "Last-Translator: Onno Giesmann <nutzer3105@gmail.com>\n"
 "Language-Team: German <--->\n"
 "Language: de\n"
@@ -755,13 +755,15 @@ msgstr "Entwicklungsfunktionen"
 
 #: src/properties.py:93
 msgid "This surface format already supports transparency."
-msgstr ""
+msgstr "Dieses Farbmodell unterstützt bereits Transparenz."
 
 #: src/properties.py:96
 msgid ""
 "This surface format doesn't support transparency, you can add an alpha "
 "channel, optionally by replacing a color."
 msgstr ""
+"Dieses Farbmodell unterstützt keine Transparenz. Sie können aber einen "
+"Alphakanal hinzufügen, zum Beispiel durch Ersetzen einer Farbe."
 
 #: src/utilities.py:124
 msgid "Continue"


### PR DESCRIPTION
Translated the two last strings. Now it's complete for de.

I think u can use "color model" as a good alternative for "surface format". It describes RGBA (with the 4th channel alpha) and RGB (no transparency).

Best regards from germany.