### PR TITLE
Debian packaging: Switch to all arch and bump version

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+drawing (0.4.7) unstable; urgency=low
+
+  * Version bump
+
+ -- Romain F. T. <rrroschan@gmail.com>  Thu, 10 Oct 2019 20:34:00 +0100
+
 drawing (0.4.6) unstable; urgency=low
 
   * Bug fixes

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 4.4.0
 Homepage: https://maoschanz.github.io/drawing/
 
 Package: drawing
-Architecture: any
+Architecture: all
 Depends: python3-gi-cairo (>=3.26.0), gir1.2-gtk-3.0 (>=3.22.30)
 Description: A drawing application for the GNOME desktop.
  A simple application to draw or edit pictures.


### PR DESCRIPTION
Debian/control specifies architecture: any. This changes it to architecture: all, so we end up with an _all.deb that works everywhere, without needing to compile Drawing separately for each architecture

The version in debian/changelog was still at 0.4.6 despite the version bump, this bumps it to 0.4.7.