### PR TITLE
UI: Add primary-toolbar CSS style to toolbars

### DIFF
--- a/src/ui/toolbar-symbolic.ui
+++ b/src/ui/toolbar-symbolic.ui
@@ -175,6 +175,9 @@
             <property name="homogeneous">False</property>
           </packing>
         </child>
+        <style>
+          <class name="primary-toolbar"/>
+        </style>
       </object>
     </child>
     <child>

--- a/src/ui/toolbar.ui
+++ b/src/ui/toolbar.ui
@@ -175,6 +175,9 @@
             <property name="homogeneous">False</property>
           </packing>
         </child>
+        <style>
+          <class name="primary-toolbar"/>
+        </style>
       </object>
     </child>
     <child>


### PR DESCRIPTION
Adds the .primary-toolbar class name to the toolbars CSS to make them look like proper toolbars. Here's an example of a theme for which this makes a difference:

Before:

![image](https://user-images.githubusercontent.com/1138515/68127391-b5b97a00-ff0d-11e9-96a2-4f2d4f4418cd.png)

After:

![image](https://user-images.githubusercontent.com/1138515/68127351-a0445000-ff0d-11e9-9cac-b046b584cfae.png)
