### PR TITLE
Pass the explicit length argument to Pango.Layout's set_text in text tool

### DIFF
--- a/src/tools/classic_tools/tool_text.py
+++ b/src/tools/classic_tools/tool_text.py
@@ -261,7 +261,7 @@ class ToolText(AbstractClassicTool):
 
 	def _show_text_with_options(self, cc, pl, text, text_x, text_y):
 		cc.move_to(text_x, text_y)
-		pl.set_text(text)
+		pl.set_text(text, -1)
 		PangoCairo.update_layout(cc, pl)
 		PangoCairo.show_layout(cc, pl)
 


### PR DESCRIPTION
This is required by older binding versions.

Fixes #275