### PR TITLE
Selector for theme variant (default, light or dark)

### DIFF
--- a/data/com.github.maoschanz.drawing.gschema.xml
+++ b/data/com.github.maoschanz.drawing.gschema.xml
@@ -67,7 +67,6 @@
       <description>Can be 'default', 'light' or 'dark'.</description>
     </key>
     
-
     <!-- Default new canvas -->
     <key type="as" name="default-rgba">
       <default>['1.0', '1.0', '1.0', '1.0']</default>

--- a/data/com.github.maoschanz.drawing.gschema.xml
+++ b/data/com.github.maoschanz.drawing.gschema.xml
@@ -61,6 +61,12 @@
       <summary>Experimental features</summary>
       <description>Turn on devel features (not recommended).</description>
     </key>
+    <key type="s" name="theme-variant">
+      <default>'default'</default>
+      <summary>Theme variant</summary>
+      <description>Can be 'default', 'light' or 'dark'.</description>
+    </key>
+    
 
     <!-- Default new canvas -->
     <key type="as" name="default-rgba">

--- a/po/drawing.pot
+++ b/po/drawing.pot
@@ -1034,15 +1034,15 @@ msgid "Theme variant"
 msgstr ""
 
 #: src/preferences.py
-msgid "Default"
+msgid "Default variant"
 msgstr ""
 
 #: src/preferences.py
-msgid "Light"
+msgid "Light variant"
 msgstr ""
 
 #: src/preferences.py
-msgid "Dark"
+msgid "Dark variant"
 msgstr ""
 
 #. This label will not be displayed in the UI of stable versions

--- a/po/drawing.pot
+++ b/po/drawing.pot
@@ -1029,6 +1029,22 @@ msgstr ""
 msgid "Preview size"
 msgstr ""
 
+#: src/preferences.py
+msgid "Theme variant"
+msgstr ""
+
+#: src/preferences.py
+msgid "Default"
+msgstr ""
+
+#: src/preferences.py
+msgid "Light"
+msgstr ""
+
+#: src/preferences.py
+msgid "Dark"
+msgstr ""
+
 #. This label will not be displayed in the UI of stable versions
 #: src/preferences.py
 msgid "Development features"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1067,16 +1067,16 @@ msgid "Theme variant"
 msgstr "Variante de thème"
 
 #: src/preferences.py
-msgid "Default"
-msgstr "Par défaut"
+msgid "Default variant"
+msgstr "Variante par défaut"
 
 #: src/preferences.py
-msgid "Light"
-msgstr "Clair"
+msgid "Light variant"
+msgstr "Variante claire"
 
 #: src/preferences.py
-msgid "Dark"
-msgstr "Foncé"
+msgid "Dark variant"
+msgstr "Variante foncée"
 
 #. This label will not be displayed in the UI of stable versions
 #: src/preferences.py

--- a/po/fr.po
+++ b/po/fr.po
@@ -1062,6 +1062,22 @@ msgstr "Options avancées"
 msgid "Preview size"
 msgstr "Taille de l'aperçu"
 
+#: src/preferences.py
+msgid "Theme variant"
+msgstr "Variante de thème"
+
+#: src/preferences.py
+msgid "Default"
+msgstr "Par défaut"
+
+#: src/preferences.py
+msgid "Light"
+msgstr "Clair"
+
+#: src/preferences.py
+msgid "Dark"
+msgstr "Foncé"
+
 #. This label will not be displayed in the UI of stable versions
 #: src/preferences.py
 msgid "Development features"

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -164,13 +164,16 @@ class DrPrefsWindow(Gtk.Window):
 		else:
 			self._gsettings.set_boolean('devel-only', False)
 		self.add_colorbtn(_("Background color"), 'ui-background-rgba')
+
+		self.add_section_separator()
 		
+		self.add_section_title(_("Theme variant"))
 		variants_dict = {
 			'default': _("Default"),
 			'light': _("Light"),
 			'dark': _("Dark")
 		}
-		self.add_combobox(_("Theme variant"), 'theme-variant', variants_dict)
+		self.add_radio_flowbox('theme-variant', variants_dict)
 
 		self.add_section_separator()
 		# Context: title of a section of the preferences. It corresponds to the
@@ -287,14 +290,6 @@ class DrPrefsWindow(Gtk.Window):
 		btn.connect('toggled', self.on_check_btn_changed, key, row_id)
 		return btn
 
-	def add_combobox(self, label_text, setting_key, labels_dict):
-		combobox = Gtk.ComboBoxText()
-		for id0 in labels_dict:
-			combobox.append(id0, labels_dict[id0])
-		combobox.set_active_id(self._gsettings.get_string(setting_key))
-		combobox.connect('changed', self.on_combobox_changed, setting_key)
-		self.add_row(label_text, combobox)
-
 	############################################################################
 	# Generic callbacks ########################################################
 
@@ -320,9 +315,6 @@ class DrPrefsWindow(Gtk.Window):
 		c = color_btn.get_rgba()
 		color_array = [str(c.red), str(c.green), str(c.blue), str(c.alpha)]
 		self._gsettings.set_strv(key, color_array)
-
-	def on_combobox_changed(self, combobox, key):
-		self._gsettings.set_string(key, combobox.get_active_id())
 
 	############################################################################
 	# Low-level packing ########################################################

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -164,7 +164,12 @@ class DrPrefsWindow(Gtk.Window):
 		else:
 			self._gsettings.set_boolean('devel-only', False)
 		self.add_colorbtn(_("Background color"), 'ui-background-rgba')
-
+		variants_dict = {
+			'default': _("Default"),
+			'light': _("Light"),
+			'dark': _("Dark")
+		}
+		self.add_combobox(_("Theme variant"), 'theme-variant', variants_dict)
 		self.add_section_separator()
 		# Context: title of a section of the preferences. It corresponds to the
 		# window layout (header-bar? tool-bar? menu-bar?)
@@ -280,6 +285,14 @@ class DrPrefsWindow(Gtk.Window):
 		btn.connect('toggled', self.on_check_btn_changed, key, row_id)
 		return btn
 
+	def add_combobox(self, label_text, setting_key, labels_dict):
+		combobox = Gtk.ComboBoxText()
+		for id0 in labels_dict:
+			combobox.append(id0, labels_dict[id0])
+		combobox.set_active_id(self._gsettings.get_string(setting_key))
+		combobox.connect('changed', self.on_combobox_changed, setting_key)
+		self.add_row(label_text, combobox)
+
 	############################################################################
 	# Generic callbacks ########################################################
 
@@ -305,6 +318,9 @@ class DrPrefsWindow(Gtk.Window):
 		c = color_btn.get_rgba()
 		color_array = [str(c.red), str(c.green), str(c.blue), str(c.alpha)]
 		self._gsettings.set_strv(key, color_array)
+
+	def on_combobox_changed(self, combobox, key):
+		self._gsettings.set_string(key, combobox.get_active_id())
 
 	############################################################################
 	# Low-level packing ########################################################

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -164,12 +164,14 @@ class DrPrefsWindow(Gtk.Window):
 		else:
 			self._gsettings.set_boolean('devel-only', False)
 		self.add_colorbtn(_("Background color"), 'ui-background-rgba')
+		
 		variants_dict = {
 			'default': _("Default"),
 			'light': _("Light"),
 			'dark': _("Dark")
 		}
 		self.add_combobox(_("Theme variant"), 'theme-variant', variants_dict)
+
 		self.add_section_separator()
 		# Context: title of a section of the preferences. It corresponds to the
 		# window layout (header-bar? tool-bar? menu-bar?)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -169,9 +169,9 @@ class DrPrefsWindow(Gtk.Window):
 		
 		self.add_section_title(_("Theme variant"))
 		variants_dict = {
-			'default': _("Default"),
-			'light': _("Light"),
-			'dark': _("Dark")
+			'default': _("Default variant"),
+			'light': _("Light variant"),
+			'dark': _("Dark variant")
 		}
 		self.add_radio_flowbox('theme-variant', variants_dict)
 

--- a/src/window.py
+++ b/src/window.py
@@ -107,6 +107,9 @@ class DrWindow(Gtk.ApplicationWindow):
 
 		if self.gsettings.get_boolean('maximized'):
 			self.maximize()
+
+		self.update_theme_variant()
+		
 		# self.resize(360, 648)
 		# self.resize(720, 288)
 		self.set_ui_bars()
@@ -418,6 +421,7 @@ class DrWindow(Gtk.ApplicationWindow):
 		# self.gsettings.connect('changed::preview-size', self.show_info_settings)
 		# self.gsettings.connect('changed::devel-only', self.show_info_settings)
 		self.gsettings.connect('changed::disabled-tools', self.show_info_settings)
+		self.gsettings.connect('changed::theme-variant', self.update_theme_variant)
 		# Other settings are connected in DrImage
 
 		# What happens when the active image change
@@ -575,6 +579,14 @@ class DrWindow(Gtk.ApplicationWindow):
 			name = 'default'
 		cursor = Gdk.Cursor.new_from_name(Gdk.Display.get_default(), name)
 		self.get_window().set_cursor(cursor)
+
+	def update_theme_variant(self, *args):
+		label = 'gtk-application-prefer-dark-theme';
+		variant = self.gsettings.get_string('theme-variant')
+		if variant == 'default':
+			Gtk.Settings.get_default().reset_property(label)
+		else:
+			Gtk.Settings.get_default().set_property(label, variant == 'dark')
 
 	############################################################################
 	# WINDOW DECORATIONS AND LAYOUTS ###########################################

--- a/src/window.py
+++ b/src/window.py
@@ -108,7 +108,7 @@ class DrWindow(Gtk.ApplicationWindow):
 		if self.gsettings.get_boolean('maximized'):
 			self.maximize()
 
-		self.update_theme_variant()
+		self._update_theme_variant()
 		
 		# self.resize(360, 648)
 		# self.resize(720, 288)
@@ -421,7 +421,7 @@ class DrWindow(Gtk.ApplicationWindow):
 		# self.gsettings.connect('changed::preview-size', self.show_info_settings)
 		# self.gsettings.connect('changed::devel-only', self.show_info_settings)
 		self.gsettings.connect('changed::disabled-tools', self.show_info_settings)
-		self.gsettings.connect('changed::theme-variant', self.update_theme_variant)
+		self.gsettings.connect('changed::theme-variant', self._update_theme_variant)
 		# Other settings are connected in DrImage
 
 		# What happens when the active image change
@@ -580,14 +580,6 @@ class DrWindow(Gtk.ApplicationWindow):
 		cursor = Gdk.Cursor.new_from_name(Gdk.Display.get_default(), name)
 		self.get_window().set_cursor(cursor)
 
-	def update_theme_variant(self, *args):
-		label = 'gtk-application-prefer-dark-theme';
-		variant = self.gsettings.get_string('theme-variant')
-		if variant == 'default':
-			Gtk.Settings.get_default().reset_property(label)
-		else:
-			Gtk.Settings.get_default().set_property(label, variant == 'dark')
-
 	############################################################################
 	# WINDOW DECORATIONS AND LAYOUTS ###########################################
 
@@ -726,6 +718,14 @@ class DrWindow(Gtk.ApplicationWindow):
 		controls_hidden = self.lookup_action('hide_controls').get_state()
 		should_show = (self.notebook.get_n_pages() > 1) and not controls_hidden
 		self.notebook.set_show_tabs(should_show)
+
+	def _update_theme_variant(self, *args):
+		key = 'gtk-application-prefer-dark-theme';
+		variant = self.gsettings.get_string('theme-variant')
+		if variant == 'default':
+			Gtk.Settings.get_default().reset_property(key)
+		else:
+			Gtk.Settings.get_default().set_property(key, variant == 'dark')
 
 	############################################################################
 	# FULLSCREEN ###############################################################


### PR DESCRIPTION
Issue: #360 

This adds a selector for the theme variant in the advanced pane of the settings.

![Capture d’écran du 2021-04-23 22-05-45](https://user-images.githubusercontent.com/50751082/115924495-15983d80-a480-11eb-9fcd-1eb37f319a6e.png)

I have used the same wording as in Gnome terminal, that is:
- Default (Par défaut)
- Light (Clair)
- Dark (Foncé)
