### PR TITLE
Improved undo performance.

### DIFF
--- a/src/history_manager.py
+++ b/src/history_manager.py
@@ -5,6 +5,35 @@ from gi.repository import Gdk, Gio, GdkPixbuf, GLib
 
 ################################################################################
 
+# 
+class State():
+
+	def __init__(self, saved_state, max_operations=20):
+
+		# A saved state operation, containing a pixbuf, width, height...
+		self.initial_state = saved_state
+
+		# The next operations following self.initial state.
+		# This list can have at most max_operations items.
+		self.operations = []
+
+		self._max_operations = max_operations
+		
+	# Convenience methods.
+
+	def pop_last_operation(self):
+		return self.operations.pop() if len(self.operations) > 0 else None
+	
+	def add_operation(self, op):
+		self.operations.append(op)
+
+	def is_empty(self):
+		return len(self.operations) == 0
+
+	def is_full(self):
+		return len(self.operations) == self._max_operations
+
+
 class DrHistoryManager():
 	__gtype_name__ = 'DrHistoryManager'
 
@@ -21,14 +50,15 @@ class DrHistoryManager():
 		# in all situations around a saving
 		return self._is_saved
 
+	def get_initial_operation(self):
+		return self._undo_history[-1].initial_state
+
+
 	def empty_history(self):
 		"""Probably useless way to explicitely 'forget' the objects. It doesn't
 		really free the memory, but it kinda helps i suppose."""
-		for op in self._undo_history:
-			self._delete_operation(op)
-		for op in self._redo_history:
-			self._delete_operation(op)
-		self._delete_operation(self.initial_operation)
+		self._undo_history.clear()
+		self._redo_history.clear()
 
 	def _delete_operation(self, op):
 		for key in op:
@@ -40,26 +70,31 @@ class DrHistoryManager():
 	# Controls accessed by DrImage #############################################
 
 	def try_undo(self):
+
 		if self._operation_is_ongoing():
 			self._image.active_tool().cancel_ongoing_operation()
 			return
-		if len(self._undo_history) > 0:
-			last_op = self._undo_history.pop()
-			self._redo_history.append(last_op)
-		self._rebuild_from_history_async()
-		self._image.update_history_sensitivity()
+		
+		undone_op = self._undo_history[-1].pop_last_operation()
+		if undone_op is not None:
+			self._redo_history.append(undone_op)
+
+			# Never pop the first saved state.
+			if self._undo_history[-1].is_empty() and len(self._undo_history) > 1:
+				self._undo_history.pop()
+
+			self._rebuild_from_history_async()
+			self._image.update_history_sensitivity()
 
 	def try_redo(self, *args):
 		operation = self._redo_history.pop()
-		if operation['tool_id'] is None:
-			self._undo_history.append(operation)
-			self._image.restore_last_state()
-		else:
-			self._get_tool(operation['tool_id']).apply_operation(operation)
+		self._get_tool(operation['tool_id']).apply_operation(operation)
+		self.add_operation(operation)
 
 	def can_undo(self):
 		# XXX incorrect si ya des states et qu'on redo
-		return (len(self._undo_history) > 0) or self._operation_is_ongoing()
+		return (len(self._undo_history[-1].operations) > 0 
+				or self._operation_is_ongoing())
 
 	def can_redo(self):
 		# XXX incorrect si ya des states ?
@@ -95,14 +130,18 @@ class DrHistoryManager():
 	# Serialized operations ####################################################
 
 	def add_operation(self, operation):
+
 		self._image.set_surface_as_stable_pixbuf()
-		# print('add_operation_to_history')
-		# print(operation['tool_id'])
-		# if 'select' in operation['tool_id']:
-		# 	print(operation['operation_type'])
-		# 	print('-----------------------------------')
+
+
+		if self._undo_history[-1].is_full():
+			self.add_state(self._image.main_pixbuf.copy())
+
+		self._undo_history[-1].add_operation(operation)
+		# TODO: clear redo_history after a new operation is 
+		# drawn (manually) by the user.
+		# self._redo_history.clear()	
 		self._is_saved = False
-		self._undo_history.append(operation)
 
 	############################################################################
 	# Cached pixbufs ###########################################################
@@ -112,54 +151,55 @@ class DrHistoryManager():
 		g = float(rgba_array[1])
 		b = float(rgba_array[2])
 		a = float(rgba_array[3])
-		self.initial_operation = {
+		initial_operation = {
 			'tool_id': None,
 			'pixbuf': pixbuf,
 			'rgba': Gdk.RGBA(red=r, green=g, blue=b, alpha=a),
 			'width': width, 'height': height
 		}
+		self._undo_history.append(State(initial_operation))
 
 	def add_state(self, pixbuf):
+
 		if pixbuf is None:
 			# Context: an error message
-			raise Exception(_("Attempt to save an invalid state"))
-		self._undo_history.append({
+			raise Exception("Attempt to save an invalid state")
+		
+		new_state = {
 			'tool_id': None,
 			'pixbuf': pixbuf,
 			'width': pixbuf.get_width(),
 			'height': pixbuf.get_height()
-		})
+		}
+
+		self._undo_history.append(State(new_state))
 		self._is_saved = True
 
 	def has_initial_pixbuf(self):
-		return self.initial_operation['pixbuf'] is not None
+		return len(self._undo_history) > 0
 
-	def get_last_saved_state(self):
-		index = self._get_last_state_index(False)
-		if index == -1:
-			return self.initial_operation
-		else:
-			return self._undo_history[index]
+	def get_last_saved_state(self):	
+		return self._undo_history[-1].initial_state
 
-	def _get_last_state_index(self, allow_yeeting_states):
-		"""Return the index of the last "state" operation (dict whose 'tool_id'
-		value is None) in the undo-history. If there is no such operation, the
-		returned index is -1 which means the only known state is the
-		self.initial_operation attribute."""
+	# def _get_last_state_index(self, allow_yeeting_states):
+	# 	"""Return the index of the last "state" operation (dict whose 'tool_id'
+	# 	value is None) in the undo-history. If there is no such operation, the
+	# 	returned index is -1 which means the only known state is the
+	# 	self.initial_operation attribute."""
 
-		returned_index = -1
-		nbPixbufs = 0
-		for op in self._undo_history:
-			if op['tool_id'] is None:
-				last_saved_pixbuf_op = op
-				returned_index = self._undo_history.index(op)
-				nbPixbufs += 1
+	# 	returned_index = -1
+	# 	nbPixbufs = 0
+	# 	for op in self._undo_history:
+	# 		if op['tool_id'] is None:
+	# 			last_saved_pixbuf_op = op
+	# 			returned_index = self._undo_history.index(op)
+	# 			nbPixbufs += 1
 
-		# TODO if there are too many pixbufs in the history, remove a few ones
-		# Issue #200, needs more design because saving can change the data
+	# 	# TODO if there are too many pixbufs in the history, remove a few ones
+	# 	# Issue #200, needs more design because saving can change the data
 
-		# print("returned_index : " + str(returned_index))
-		return returned_index
+	# 	# print("returned_index : " + str(returned_index))
+	# 	return returned_index
 
 	############################################################################
 	# Other private methods ####################################################
@@ -182,17 +222,14 @@ class DrHistoryManager():
 			return False
 		self._waiting_for_rebuild = False
 
-		last_save_index = self._get_last_state_index(True)
 		self._image.restore_last_state()
-		history = self._undo_history.copy()
-		self._undo_history = []
-		for op in history:
-			if history.index(op) > last_save_index:
-				# print("do", op['tool_id'])
-				self._get_tool(op['tool_id']).simple_apply_operation(op)
-			else:
-				# print("skip", op['tool_id'])
-				self._undo_history.append(op)
+
+		x = self._undo_history[-1].operations
+		self._undo_history[-1].operations = []
+
+		for op in x:
+			self._get_tool(op['tool_id']).simple_apply_operation(op)
+	
 		self._image.update()
 		return False
 
@@ -204,7 +241,7 @@ class DrHistoryManager():
 		if tool_id in all_tools:
 			return all_tools[tool_id]
 		else:
-			self._image.window.reveal_action_report(_("Error: no tool '%s'" % tool_id))
+			self._image.window.reveal_action_report("Error: no tool '%s'" % tool_id)
 			# no raise: this may happen normally if last_save_index is incorrect
 
 	############################################################################

--- a/src/image.py
+++ b/src/image.py
@@ -176,7 +176,7 @@ class DrImage(Gtk.Box):
 	def restore_last_state(self):
 		"""Set the last saved pixbuf from the history as the main_pixbuf. This
 		is used to rebuild the picture from its history."""
-		last_saved_pixbuf_op = self._history.get_last_saved_state()
+		last_saved_pixbuf_op = self._history.get_last_stored_state()
 		self._apply_state(last_saved_pixbuf_op)
 
 	def reset_to_initial_pixbuf(self):
@@ -229,7 +229,6 @@ class DrImage(Gtk.Box):
 		self.window.update_picture_title()
 		self.use_stable_pixbuf()
 		self.update()
-		self.remember_current_state()
 
 	def try_load_file(self, gfile):
 		try:
@@ -312,6 +311,7 @@ class DrImage(Gtk.Box):
 		if not self.is_saved():
 			main_title = "*" + main_title
 		self.set_tab_label(main_title)
+
 		return main_title
 
 	def get_filename_for_display(self):

--- a/src/image.py
+++ b/src/image.py
@@ -180,7 +180,7 @@ class DrImage(Gtk.Box):
 		self._apply_state(last_saved_pixbuf_op)
 
 	def reset_to_initial_pixbuf(self):
-		self._apply_state(self._history.initial_operation)
+		self._apply_state(self._history.get_initial_operation())
 		self._history.rewind_history()
 
 	def _apply_state(self, state_op):
@@ -379,7 +379,7 @@ class DrImage(Gtk.Box):
 		return not self._history.has_initial_pixbuf()
 
 	def get_initial_rgba(self):
-		return self._history.initial_operation['rgba']
+		return self._history.get_initial_operation()['rgba']
 
 	############################################################################
 	# Misc ? ###################################################################


### PR DESCRIPTION
The two main performance bottlenecks were:

1. Having to loop over the whole history to find the last remembered state.
2. If the user doesn't save to disk, to undo the last action the drawing was always being rebuilt from the initial operation.

To address these issues, the class **_State_** was made (it could be turned into a dict, but I feel a class fits better for this). This new class contains a remembered state, as well as the next __max_operations_ following operations.

Now the __undo_history_ attribute is a list of **_State_** objects instead of individual operations. This lets us access the last remembered state in constant time instead of having to loop over all previous operations. (the __redo_history_ remains exactly the same)

When a new operation arrives, it is stored in the last entry of the  __undo_history_ list only if there's less than __max_operations_ operations stored in that object. Otherwise, a new **_State_** object containing a copy of the current pixbuf is appended to the list, and the operation is saved there.

These changes are specially noticeable when the user has drawn a lot of operations, because we don't have to loop over all of them, and to redraw the picture we only have to redraw at most __max_operations_ operations.

For now, I've set the value of __max_operations_  to 20, but this value can be easily changed. It might be a good idea to create new settings in the preferences menu where the user could change this value, as well as the maximum memory the _history_manager_ is allowed to use.

Resolves #200 
