### PR TITLE
help-overlay: Remove excessive action

### DIFF
--- a/src/drawing.gresource.xml
+++ b/src/drawing.gresource.xml
@@ -10,7 +10,7 @@
     <file>ui/properties.ui</file>
     <file>ui/preferences.ui</file>
     <file>ui/selection-manager.ui</file>
-    <file>ui/shortcuts.ui</file>
+    <file alias="gtk/help-overlay.ui">ui/shortcuts.ui</file>
     <file>ui/toolbar.ui</file>
     <file>ui/toolbar-symbolic.ui</file>
     <file>ui/win-menus.ui</file>

--- a/src/main.py
+++ b/src/main.py
@@ -102,8 +102,6 @@ class Application(Gtk.Application):
 		self.add_action_simple('help_whats_new', self.on_help_whats_new)
 
 		self.add_action_simple('report-issue', self.on_report)
-		self.add_action_simple('shortcuts', self.on_shortcuts, \
-		                                         ['<Ctrl>question', '<Ctrl>F1'])
 		self.add_action_simple('about', self.on_about, ['<Shift>F1'])
 		self.add_action_simple('quit', self.on_quit, ['<Ctrl>q'])
 
@@ -231,14 +229,6 @@ class Application(Gtk.Application):
 		"""Action callback, opening a new issue on the github repo."""
 		win = self.props.active_window
 		Gtk.show_uri_on_window(win, self.BUG_REPORT_URL, Gdk.CURRENT_TIME)
-
-	def on_shortcuts(self, *args):
-		"""Action callback, showing the 'shortcuts' dialog."""
-		if self.shortcuts_window is not None:
-			self.shortcuts_window.destroy()
-		builder = Gtk.Builder().new_from_resource(self.APP_PATH + '/ui/shortcuts.ui')
-		self.shortcuts_window = builder.get_object('shortcuts-window')
-		self.shortcuts_window.present()
 
 	def on_prefs(self, *args):
 		"""Action callback, showing the preferences window."""

--- a/src/ui/app-menus.ui
+++ b/src/ui/app-menus.ui
@@ -486,7 +486,7 @@
       <section>
         <item>
           <attribute name="label" translatable="yes">Shortcuts</attribute>
-          <attribute name="action">app.shortcuts</attribute>
+          <attribute name="action">win.show-help-overlay</attribute>
           <attribute name="verb-icon">input-keyboard-symbolic</attribute>
         </item>
       </section>

--- a/src/ui/shortcuts.ui
+++ b/src/ui/shortcuts.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface domain="drawing">
-  <object class="GtkShortcutsWindow" id="shortcuts-window">
+  <object class="GtkShortcutsWindow" id="help_overlay">
     <property name="icon-name">com.github.maoschanz.drawing</property>
     <child>
       <object class="GtkShortcutsSection">

--- a/src/ui/win-menus.ui
+++ b/src/ui/win-menus.ui
@@ -122,7 +122,7 @@
     <section>
       <item>
         <attribute name="label" translatable="yes">Shortcuts</attribute>
-        <attribute name="action">app.shortcuts</attribute>
+        <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
         <attribute name="action">app.help</attribute>
@@ -217,7 +217,7 @@
     <section>
       <item>
         <attribute name="label" translatable="yes">Shortcuts</attribute>
-        <attribute name="action">app.shortcuts</attribute>
+        <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
         <attribute name="action">app.help</attribute>
@@ -280,7 +280,7 @@
     <section>
       <item>
         <attribute name="label" translatable="yes">Shortcuts</attribute>
-        <attribute name="action">app.shortcuts</attribute>
+        <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
         <attribute name="action">app.help</attribute>


### PR DESCRIPTION
We don't need an extra action to show help-overlay. It already managed by GTK.

Source: https://docs.gtk.org/gtk4/class.Application.html#automatic-resources