### PR TITLE
debian/control is missing a depend on debhelper

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: drawing
 Section: graphics
 Priority: optional
 Maintainer: Romain F. T. <rrroschan@gmail.com>
-Build-Depends: meson (>=0.50), appstream-util (>=0.7.14), libglib2.0-dev-bin (>=2.58.3), itstool, python3-cairo, python3-gi (>=3.30.0)
+Build-Depends: debhelper, meson (>=0.50), appstream-util (>=0.7.14), libglib2.0-dev-bin (>=2.58.3), itstool, python3-cairo, python3-gi (>=3.30.0)
 Standards-Version: 4.4.0
 Homepage: https://maoschanz.github.io/drawing/
 


### PR DESCRIPTION
Hi,

At first thanks for your work, it is a nice and easy piece of software, avoiding me using the gimp.

The Debian Sid version is [totally outdated](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1028955), so I decided to build a deb package from your debianisation, with `pbuilder` because it is the right way(tm) of doing it (it builds packages in empty chroots), here is [some getting started documentation](https://wiki.debian.org/Diaspora/Packaging/pbuilder).

I found out that your `debian/control` file is missing a build depend on `debhelper`, so Drawing cannot be built using  `pbuilder`. This PR adds the missing dependency.