### PR TITLE
help-overlay: use sentence capitalization

### DIFF
--- a/src/ui/shortcuts.ui
+++ b/src/ui/shortcuts.ui
@@ -16,7 +16,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">New Window</property>
+                <property name="title" translatable="yes">New window</property>
                 <property name="action-name">app.new_window</property>
               </object>
             </child>
@@ -78,14 +78,14 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">New Blank Image</property>
+                <property name="title" translatable="yes">New blank image</property>
                 <property name="action-name">win.new_tab</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">New Image From Clipboard</property>
+                <property name="title" translatable="yes">New image from clipboard</property>
                 <property name="action-name">win.new_tab_clipboard</property>
               </object>
             </child>
@@ -204,21 +204,21 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Zoom Out</property>
+                <property name="title" translatable="yes">Zoom out</property>
                 <property name="accelerator">&lt;Primary&gt;minus</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Original Zoom</property>
+                <property name="title" translatable="yes">Original zoom</property>
                 <property name="accelerator">&lt;Primary&gt;1</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Zoom In</property>
+                <property name="title" translatable="yes">Zoom in</property>
                 <property name="accelerator">&lt;Primary&gt;plus</property>
               </object>
             </child>
@@ -232,7 +232,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Optimal Zoom</property>
+                <property name="title" translatable="yes">Optimal zoom</property>
                 <property name="accelerator">&lt;Primary&gt;0</property>
               </object>
             </child>
@@ -289,7 +289,7 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">New Image From Selection</property>
+                <property name="title" translatable="yes">New image from selection</property>
                 <property name="action-name">win.new_tab_selection</property>
               </object>
             </child>
@@ -369,28 +369,28 @@
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Go Left</property>
+                <property name="title" translatable="yes">Go left</property>
                 <property name="action-name">win.go_left</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Go Up</property>
+                <property name="title" translatable="yes">Go up</property>
                 <property name="action-name">win.go_up</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Go Down</property>
+                <property name="title" translatable="yes">Go down</property>
                 <property name="action-name">win.go_down</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
-                <property name="title" translatable="yes">Go Right</property>
+                <property name="title" translatable="yes">Go right</property>
                 <property name="action-name">win.go_right</property>
               </object>
             </child>
@@ -473,7 +473,7 @@
       <object class="GtkShortcutsSection">
         <property name="visible">True</property>
         <property name="section-name">gestures</property>
-        <property name="title" translatable="yes">Touch gestures</property>
+        <property name="title" translatable="yes">Touch Gestures</property>
         <property name="max-height">5</property>
 
         <child>
@@ -484,14 +484,14 @@
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
                 <property name="shortcut-type">gesture-pinch</property>
-                <property name="title" translatable="yes">Zoom Out</property>
+                <property name="title" translatable="yes">Zoom out</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
                 <property name="shortcut-type">gesture-stretch</property>
-                <property name="title" translatable="yes">Zoom In</property>
+                <property name="title" translatable="yes">Zoom in</property>
               </object>
             </child>
           </object>


### PR DESCRIPTION
Use sentence capitalization for the shortcut entries.