### PR TITLE
appdata: add vcs-browser and translate support

### DIFF
--- a/data/com.github.maoschanz.drawing.appdata.xml.in
+++ b/data/com.github.maoschanz.drawing.appdata.xml.in
@@ -163,8 +163,11 @@
 
   <developer_name translatable="no">Romain F. T.</developer_name>
   <update_contact>rrroschan@gmail.com</update_contact>
-  <url type="bugtracker">https://github.com/maoschanz/drawing/issues</url>
   <url type="homepage">https://maoschanz.github.io/drawing</url>
+  <url type="bugtracker">https://github.com/maoschanz/drawing/issues</url>
+  <url type="contribute">https://github.com/maoschanz/drawing/blob/master/CONTRIBUTING.md</url>
+  <url type="translate">https://github.com/maoschanz/drawing/blob/master/CONTRIBUTING.md#translating</url>
+  <url type="vcs-browser">https://github.com/maoschanz/drawing/</url>
   <url type="donation">https://paypal.me/maoschannz</url>
 
   <screenshots>


### PR DESCRIPTION
These URLs are visible on Flathub and GNOME Control Center.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url