### PR TITLE
appdata: Remove Purism metadata

### DIFF
--- a/data/com.github.maoschanz.drawing.appdata.xml.in
+++ b/data/com.github.maoschanz.drawing.appdata.xml.in
@@ -9,10 +9,6 @@
     <kudo>ModernToolkit</kudo>
     <kudo>UserDocs</kudo>
   </kudos>
-  <custom>
-    <value key="Purism::form_factor">workstation</value>
-    <value key="Purism::form_factor">mobile</value>
-  </custom>
   <content_rating type="oars-1.1" />
 
   <name>Drawing</name>


### PR DESCRIPTION
This metadata is invalid: custom data is a dictionary and using the same key multiple times in a dictionary does not work.

More information: https://github.com/ximion/appstream/issues/476