### PR TITLE
Appdata related paches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -260,7 +260,7 @@ options, the right building tools, and luck.
 - `meson`. The version of meson required by the `meson.build` file at the root
 of the project can be changed if necessary, but please don't add this change to
 your commit(s).
-- [optional] `appstream-util` (validation of the `.appdata.xml` file)
+- [optional] `appstreamcli` (validation of the `.appdata.xml` file)
 - `libglib2.0-dev-bin` (IIRC that one is to compress the `.ui` files and the
 icons into a `.gresource` file: 100% necessary)
 - [optional] `itstool` (to generate translation files for the help manual)

--- a/com.github.maoschanz.drawing.json
+++ b/com.github.maoschanz.drawing.json
@@ -1,7 +1,7 @@
 {
 	"app-id" : "com.github.maoschanz.drawing",
 	"runtime" : "org.gnome.Platform",
-	"runtime-version" : "44",
+	"runtime-version" : "45",
 	"sdk" : "org.gnome.Sdk",
 	"command" : "drawing",
 	"finish-args" : [

--- a/data/com.github.maoschanz.drawing.appdata.xml.in
+++ b/data/com.github.maoschanz.drawing.appdata.xml.in
@@ -33,6 +33,17 @@
     <p>Supported file types include PNG, JPEG and BMP.</p>
   </description>
 
+  <categories>
+    <category>Graphics</category>
+  </categories>
+  
+  <keywords>
+    <keyword translate="no">drawing</keyword>
+    <keyword>Paint</keyword>
+    <keyword>Sketch</keyword>
+    <keyword>Pencil</keyword>
+  </keywords>
+  
   <releases>
     <release version="1.2.0" date="2023-04-29">
     <!-- TODO actual date -->

--- a/data/meson.build
+++ b/data/meson.build
@@ -38,16 +38,13 @@ if get_option('enable-translations-and-appdata')
 		install_dir: join_paths(get_option('datadir'), 'metainfo')
 	)
 
-	appstream_util = find_program('appstream-util', required: false)
-	if appstream_util.found()
+	appstreamcli = find_program('appstreamcli', required: false)
+	if appstreamcli.found()
 		test(
 			'Validate appstream file',
-			appstream_util,
-			args: ['validate', appstream_file]
+			appstreamcli,
+			args: ['validate', '--no-net', appstream_file]
 		)
-		# The app will never pass "validate-strict" because appstream-util wants
-		# pictures with a 16:9 ratio, while i use pictures of the default window
-		# size, which is approximating the objectively better golden ratio.
 	endif
 endif
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -5,21 +5,20 @@
 # OverflowCat <overflowcat@gmail.com>, 2020.
 # Yi-Jyun Pan <pan93412@gmail.com>, 2020.
 # Hsiu-Ming Chang <cges30901@gmail.com>, 2020.
+# anenasa <anenasaa@yahoo.com>, 2023.
 msgid ""
 msgstr ""
 "Project-Id-Version: drawing\n"
 "Report-Msgid-Bugs-To: github.com/maoschanz/drawing/issues/new/choose\n"
 "POT-Creation-Date: 2023-02-23 23:35+0100\n"
-"PO-Revision-Date: 2020-08-29 14:15+0800\n"
-"Last-Translator: Hsiu-Ming Chang <cges30901@gmail.com>\n"
+"PO-Revision-Date: 2023-10-23 13:45+0800\n"
+"Last-Translator: anenasa <anenasaa@yahoo.com>\n"
 "Language-Team: none\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.4.1\n"
-"X-ZhConverter: 繁化姬 dict-7114b8ff-r945 @ 2020/07/24 01:45:33 | https://"
-"zhconvert.org\n"
+"X-Generator: Poedit 3.3.2\n"
 
 #: data/com.github.maoschanz.drawing.desktop.in
 #: data/com.github.maoschanz.drawing.appdata.xml.in src/deco_manager.py
@@ -52,13 +51,13 @@ msgstr "新影像"
 
 #: data/com.github.maoschanz.drawing.desktop.in
 msgid "Edit Image in Clipboard"
-msgstr "在剪貼簿中編輯影像"
+msgstr "編輯剪貼簿中的影像"
 
 #. IMPORTANT: the summarized description of the application.
 #. https://gitlab.gnome.org/GNOME/Initiatives/-/wikis/App-Metadata
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid "Edit screenshots or memes"
-msgstr ""
+msgstr "編輯螢幕擷圖或迷因"
 
 #. IMPORTANT: complete description of the application (1/3)
 #: data/com.github.maoschanz.drawing.appdata.xml.in
@@ -67,6 +66,8 @@ msgid ""
 "filters, insert or censor text, and manipulate a selected portion of the "
 "picture (cut/copy/paste/drag/…)"
 msgstr ""
+"這個基本的影像編輯器可以調整影像大小、裁切、旋轉影像，套用簡單的濾鏡，插入或"
+"刪改文字，並編輯圖片選擇的部分（剪下、複製、貼上、拖曳等）"
 
 #. IMPORTANT: complete description of the application (2/3)
 #: data/com.github.maoschanz.drawing.appdata.xml.in
@@ -75,11 +76,13 @@ msgid ""
 "line, the curve tool, many shapes, several brushes, and their various colors "
 "and options."
 msgstr ""
+"當然您可以繪圖！使用諸如鉛筆、直線、曲線，多種形狀、多種筆刷工具，具有多種色"
+"彩和選項。"
 
 #. IMPORTANT: complete description of the application (3/3)
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid "Supported file types include PNG, JPEG and BMP."
-msgstr ""
+msgstr "支援 PNG、JPEG 和 BMP 檔案格式。"
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""
@@ -275,7 +278,7 @@ msgstr "影像屬性"
 
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
 msgid "Reset canvas"
-msgstr ""
+msgstr "重設畫布"
 
 #: src/ui/app-menus.ui src/ui/headerbar.ui src/ui/headerbar-eos.ui
 #: src/ui/shortcuts.ui src/ui/toolbar.ui src/ui/toolbar-symbolic.ui
@@ -284,15 +287,14 @@ msgid "Save"
 msgstr "儲存"
 
 #: src/ui/app-menus.ui src/ui/win-menus.ui
-#, fuzzy
 msgid "Save without transparency"
-msgstr "增加透明度"
+msgstr "不帶透明度儲存"
 
 #. This "feature" is only visible on April Fools' day, and it
 #. will just rickroll the user.
 #: src/ui/app-menus.ui src/ui/win-menus.ui
 msgid "Prepare as NFT…"
-msgstr ""
+msgstr "準備為 NFT…"
 
 #: src/ui/app-menus.ui src/ui/headerbar-eos.ui src/ui/win-menus.ui
 #: src/saving_manager.py
@@ -307,7 +309,7 @@ msgstr "匯出為…"
 #: src/ui/app-menus.ui src/ui/shortcuts.ui src/ui/toolbar.ui
 #: src/ui/toolbar-symbolic.ui src/ui/win-menus.ui
 msgid "Copy to clipboard"
-msgstr ""
+msgstr "複製到剪貼簿"
 
 #: src/ui/app-menus.ui src/ui/toolbar.ui src/ui/toolbar-symbolic.ui
 #: src/ui/win-menus.ui
@@ -447,31 +449,29 @@ msgstr "向右"
 #. canvas. The "go left" action only goes a few centimeters
 #. to the left, but this one goes all the way left.
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
-#, fuzzy
 msgid "Go to the left end"
-msgstr "左側的分頁"
+msgstr "到左端"
 
 #. Context: this action scrolls to the top of the canvas
 #. The "go up" action only goes a few centimeters up, but
 #. this one goes all the way to the top.
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
 msgid "Go to the top"
-msgstr ""
+msgstr "到頂端"
 
 #. Context: this action scrolls to the bottom of the canvas
 #. The "go down" action only goes a few centimeters down,
 #. but this one goes all the way to the bottom.
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
 msgid "Go to the bottom"
-msgstr ""
+msgstr "到底端"
 
 #. Context: this action scrolls to the right end of the
 #. canvas. The "go right" action only goes a few centimeters
 #. to the right, but this one goes all the way right.
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
-#, fuzzy
 msgid "Go to the right end"
-msgstr "右側的分頁"
+msgstr "到右端"
 
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
 msgid "Tab at the left"
@@ -488,21 +488,19 @@ msgstr "重新整理"
 #. Label shown only in developer mode
 #: src/ui/app-menus.ui
 msgid "Track framerate"
-msgstr ""
+msgstr "追蹤幀率"
 
 #: src/ui/app-menus.ui
-#, fuzzy
 msgid "Dark theme variant"
-msgstr "預設寬度"
+msgstr "暗色主題變體"
 
 #: src/ui/app-menus.ui
-#, fuzzy
 msgid "Show the menu-bar"
-msgstr "切換預覽"
+msgstr "顯示選單列"
 
 #: src/ui/app-menus.ui
 msgid "Hide toolbars"
-msgstr ""
+msgstr "隱藏工具列"
 
 #: src/ui/app-menus.ui src/ui/shortcuts.ui src/ui/win-menus.ui
 msgid "Fullscreen"
@@ -543,24 +541,22 @@ msgstr "螢光筆"
 #. Context: a possible way to highlight text
 #: src/ui/app-menus.ui src/optionsbars/classic/optionsbar-operator-menus.ui
 #: src/tools/ui/tool-highlight.ui src/tools/classic_tools/tool_highlight.py
-#, fuzzy
 msgid "Dark text on light background"
-msgstr "矩形背景"
+msgstr "深色文字淺色背景"
 
 #. Context: a possible way to highlight text
 #: src/ui/app-menus.ui src/optionsbars/classic/optionsbar-operator-menus.ui
 #: src/tools/ui/tool-highlight.ui src/tools/classic_tools/tool_highlight.py
 msgid "Light text on dark background"
-msgstr ""
+msgstr "淺色文字深色背景"
 
 #. Context: possible ways to apply the color to the canvas, using
 #. only some specific dimension(s) of the selected color in its
 #. hue-saturation-luminosity (HSL) representation
 #: src/ui/app-menus.ui src/optionsbars/classic/optionsbar_color_popover.py
 #: src/optionsbars/classic/optionsbar-operator-menus.ui
-#, fuzzy
 msgid "HSL modes"
-msgstr "其他模式"
+msgstr "HSL 模式"
 
 #. Context: a possible way to apply the color to the canvas
 #: src/ui/app-menus.ui src/optionsbars/classic/optionsbar_color_popover.py
@@ -622,9 +618,8 @@ msgid "Previous tool"
 msgstr "先前的工具"
 
 #: src/ui/app-menus.ui
-#, fuzzy
 msgid "Active tool"
-msgstr "其他工具"
+msgstr "使用中的工具"
 
 #: src/ui/app-menus.ui src/ui/shortcuts.ui src/ui/win-menus.ui
 #: src/preferences.py
@@ -633,12 +628,11 @@ msgstr "顯示工具名稱"
 
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
 msgid "Bigger width"
-msgstr ""
+msgstr "較大寬度"
 
 #: src/ui/app-menus.ui src/ui/shortcuts.ui
-#, fuzzy
 msgid "Smaller width"
-msgstr "預設寬度"
+msgstr "較小寬度"
 
 #: src/ui/app-menus.ui
 msgid "Troubleshoot selection"
@@ -646,15 +640,13 @@ msgstr "對選擇區域排查問題"
 
 #: src/ui/app-menus.ui
 #: src/optionsbars/transform/abstract-optionsbar-transform.ui
-#, fuzzy
 msgid "Cancel transformation"
-msgstr "關於工具的說明"
+msgstr "取消變形"
 
 #: src/ui/app-menus.ui
 #: src/optionsbars/transform/abstract-optionsbar-transform.ui
-#, fuzzy
 msgid "Apply transformation"
-msgstr "關於工具的說明"
+msgstr "套用變形"
 
 #: src/ui/app-menus.ui
 msgid "Options"
@@ -680,7 +672,7 @@ msgstr "索引"
 #. Context: submenu listing individual help pages
 #: src/ui/app-menus.ui
 msgid "Individual pages"
-msgstr ""
+msgstr "個別頁面"
 
 #. Context: open the help page about general use of the app
 #: src/ui/app-menus.ui
@@ -688,32 +680,27 @@ msgid "Basic help"
 msgstr "基本說明"
 
 #: src/ui/app-menus.ui src/ui/minimap.ui
-#, fuzzy
 msgid "Help about zooming"
-msgstr "關於工具的說明"
+msgstr "關於縮放的說明"
 
 #: src/ui/app-menus.ui
-#, fuzzy
 msgid "Help about the full-screen mode"
-msgstr "進入全螢幕模式"
+msgstr "關於全螢幕模式的說明"
 
 #: src/ui/app-menus.ui
-#, fuzzy
 msgid "Help about classic tools"
-msgstr "關於工具的說明"
+msgstr "關於標準工具的說明"
 
 #: src/ui/app-menus.ui src/optionsbars/classic/optionsbar-color-popover.ui
-#, fuzzy
 msgid "Help about colors"
-msgstr "關於工具的說明"
+msgstr "關於色彩的說明"
 
 #. Context: open the help page about transformation tools (crop,
 #. scale, rotate, filters, ...
 #: src/ui/app-menus.ui
 #: src/optionsbars/transform/abstract-optionsbar-transform.ui
-#, fuzzy
 msgid "Help about transformation tools"
-msgstr "關於工具的說明"
+msgstr "關於變形工具的說明"
 
 #: src/ui/app-menus.ui src/optionsbars/selection/optionsbar-selection.ui
 msgid "Help about selection"
@@ -721,7 +708,7 @@ msgstr "關於選擇區域的說明"
 
 #: src/ui/app-menus.ui
 msgid "What's new"
-msgstr ""
+msgstr "新消息"
 
 #: src/ui/app-menus.ui src/ui/win-menus.ui
 msgid "About Drawing"
@@ -734,16 +721,15 @@ msgstr "開啟"
 
 #: src/ui/headerbar-eos.ui
 msgid "Share the image"
-msgstr ""
+msgstr "分享影像"
 
 #: src/ui/image.ui
 msgid "The image changed on the disk, do you want to reload it?"
-msgstr ""
+msgstr "磁碟中的影像已變更，是否重新載入？"
 
 #: src/ui/image.ui
-#, fuzzy
 msgid "Reload"
-msgstr "重新載入檔案"
+msgstr "重新載入"
 
 #: src/ui/minimap.ui
 msgid "100%"
@@ -751,7 +737,7 @@ msgstr "100%"
 
 #: src/ui/minimap.ui src/ui/shortcuts.ui
 msgid "Maximum zoom"
-msgstr ""
+msgstr "最大縮放"
 
 #: src/ui/new-image-dialog.ui src/ui/properties.ui
 #: src/optionsbars/transform/optionsbar-crop.ui
@@ -835,23 +821,21 @@ msgstr "更多操作"
 
 #: src/ui/selection-manager.ui
 #: src/optionsbars/selection/optionsbar-selection.ui src/tools/ui/selection.ui
-#, fuzzy
 msgid "Invert selection"
-msgstr "自由選擇"
+msgstr "反轉選擇區域"
 
 #. Define the image as being the currently selected area
 #: src/ui/selection-manager.ui
 #: src/optionsbars/selection/optionsbar-selection.ui src/tools/ui/selection.ui
-#, fuzzy
 msgid "Define as current image"
-msgstr "開啟影像"
+msgstr "設為目前的影像"
 
 #. Expand the canvas of the current image to make the current selection fit in it.
 #. Can be translated as "Expand to this size".
 #: src/ui/selection-manager.ui
 #: src/optionsbars/selection/optionsbar-selection.ui src/tools/ui/selection.ui
 msgid "Expand image to fit"
-msgstr ""
+msgstr "影像擴展至選擇區域"
 
 #: src/ui/selection-manager.ui
 #: src/optionsbars/selection/optionsbar-selection.ui src/tools/ui/selection.ui
@@ -871,9 +855,8 @@ msgid "Main menu"
 msgstr "主選單"
 
 #: src/ui/shortcuts.ui
-#, fuzzy
 msgid "Toggle the menu-bar"
-msgstr "切換預覽"
+msgstr "開關選單列"
 
 #: src/ui/shortcuts.ui
 msgid "Image"
@@ -896,9 +879,8 @@ msgid "Close the active image"
 msgstr "關閉使用中的影像"
 
 #: src/ui/shortcuts.ui
-#, fuzzy
 msgid "Open the tool options menu"
-msgstr "選項選單"
+msgstr "開啟工具選項選單"
 
 #: src/ui/shortcuts.ui
 msgid "Back to previous tool"
@@ -906,7 +888,7 @@ msgstr "回到先前的工具"
 
 #: src/ui/shortcuts.ui
 msgid "Apply a transformation"
-msgstr ""
+msgstr "套用變形"
 
 #: src/ui/shortcuts.ui
 msgid "Toggle the preview"
@@ -951,22 +933,20 @@ msgid "Tabs"
 msgstr "分頁"
 
 #: src/ui/shortcuts.ui
-#, fuzzy
 msgid "Toggle fullscreen mode"
-msgstr "進入全螢幕模式"
+msgstr "開關全螢幕模式"
 
 #: src/ui/shortcuts.ui
 msgid "Toggle toolbars visibility"
-msgstr ""
+msgstr "切換工具列可見性"
 
 #: src/ui/shortcuts.ui
 msgid "Touch gestures"
 msgstr "觸控手勢"
 
 #: src/ui/window.ui src/deco_manager.py
-#, fuzzy
 msgid "Loading…"
-msgstr "正在載入 %s"
+msgstr "正在載入…"
 
 #: src/ui/window.ui
 msgid "Exit fullscreen"
@@ -974,11 +954,11 @@ msgstr "結束全螢幕"
 
 #: src/ui/win-menus.ui
 msgid "What's new in Drawing"
-msgstr ""
+msgstr "Drawing 的新消息"
 
 #: src/ui/win-menus.ui
 msgid "Dismiss"
-msgstr ""
+msgstr "關閉"
 
 #: src/deco_manager.py
 #, python-format
@@ -993,18 +973,18 @@ msgstr "重做 %s"
 #. Context: an error message
 #: src/history_manager.py
 msgid "Attempt to save an invalid state"
-msgstr ""
+msgstr "嘗試儲存無效的狀態"
 
 #: src/history_manager.py
 #, python-format
 msgid "Error: no tool '%s'"
-msgstr ""
+msgstr "錯誤：沒有工具「%s」"
 
 #. Context: an error message
 #: src/image.py
 #, python-format
 msgid "New pixbuf empty, no change applied to %s"
-msgstr ""
+msgstr "新的 pixbuf 為空，未套用變更到 %s"
 
 #: src/image.py src/properties.py
 msgid "Unsaved file"
@@ -1014,7 +994,7 @@ msgstr "未儲存的檔案"
 #: src/image.py
 #, python-format
 msgid "%s frames per second"
-msgstr ""
+msgstr "每秒 %s 幀"
 
 #. Description of a command line option
 #: src/main.py
@@ -1051,7 +1031,8 @@ msgid "translator-credits"
 msgstr ""
 "OverflowCat <overflowcat@gmail.com>, 2020.\n"
 "Yi-Jyun Pan <pan93412@gmail.com>, 2020.\n"
-"Hsiu-Ming Chang <cges30901@gmail.com>, 2020."
+"Hsiu-Ming Chang <cges30901@gmail.com>, 2020.\n"
+"anenasa <anenasaa@yahoo.com>, 2023."
 
 #. To translators: this is credits for the icons, consider that "Art
 #. Libre" is proper name
@@ -1061,22 +1042,21 @@ msgstr "GNOME 的 Art Libre 圖示包作者"
 
 #: src/main.py
 msgid "Simple image editor for Linux"
-msgstr ""
+msgstr "Linux 的簡易影像編輯器"
 
 #: src/main.py
 msgid "Official webpage"
 msgstr "官方網頁"
 
 #: src/main.py
-#, fuzzy
 msgid "Error opening this file."
-msgstr "開啟此檔案時發生錯誤。你在找 %s 嗎？"
+msgstr "開啟此檔案時發生錯誤。"
 
 #. This is an error message, %s is a better command suggestion
 #: src/main.py
 #, python-format
 msgid "Did you mean %s ?"
-msgstr ""
+msgstr "你在找 %s 嗎？"
 
 #. This string displays the zoom level: %s will be replaced with a
 #. number, while %% will be rendered as the symbol '%'
@@ -1208,7 +1188,7 @@ msgstr "螢光筆"
 #: src/preferences.py src/tools/classic_tools/tool_brush.py
 #: src/tools/classic_tools/brushes/abstract_brush.py
 msgid "Brush"
-msgstr ""
+msgstr "筆刷"
 
 #. Context: this is the name of a tool to draw little circles, crosses,
 #. or squares at precise points of the image, for example to draw a vague
@@ -1217,7 +1197,7 @@ msgstr ""
 #. the elements of an image.
 #: src/preferences.py src/tools/classic_tools/tool_points.py
 msgid "Points"
-msgstr ""
+msgstr "點"
 
 #. Context: this is a tool to select an area according to a shape that
 #. can be freely defined by the user.
@@ -1241,7 +1221,7 @@ msgstr "取色器"
 #. Context: the name of a tool to fill an area of one color with an other
 #: src/preferences.py src/tools/classic_tools/tool_paint.py
 msgid "Paint"
-msgstr "筆刷"
+msgstr "填色"
 
 #. Context: the color editor is an interface to pick any RGBA color, and
 #. it can be used instead of the default simple RGB palette
@@ -1251,7 +1231,7 @@ msgstr "預設使用色彩編輯器"
 
 #: src/preferences.py
 msgid "You can use a simple color palette, or use a full RGBA color editor."
-msgstr ""
+msgstr "您可以使用簡易的調色板，或是使用完整的色彩編輯器。"
 
 #. Context: title of a section of the preferences
 #: src/preferences.py
@@ -1272,9 +1252,8 @@ msgid "Background color"
 msgstr "背景色彩"
 
 #: src/preferences.py
-#, fuzzy
 msgid "Prefer dark theme variant"
-msgstr "預設寬度"
+msgstr "偏好暗色主題變體"
 
 #. Context: title of a section of the preferences. It corresponds to the
 #. window layout (header-bar? tool-bar? menu-bar?)
@@ -1362,9 +1341,8 @@ msgstr "無效格式"
 #. an actual error occurred!
 #. Context: an error message
 #: src/saving_manager.py
-#, fuzzy
 msgid "Failed to replace transparency"
-msgstr "將透明部分取代為："
+msgstr "無法取代透明部分"
 
 #. Context: an error message
 #: src/saving_manager.py
@@ -1374,9 +1352,9 @@ msgstr "儲存 %s 失敗"
 
 #. Context: an error message
 #: src/saving_manager.py
-#, fuzzy, python-format
+#, python-format
 msgid "Failed to reload %s"
-msgstr "載入工具失敗：%s"
+msgstr "無法重新載入 %s"
 
 #. Context: Untitled(.png) is the default name of a newly saved file
 #: src/saving_manager.py
@@ -1402,34 +1380,31 @@ msgstr "%s 有未儲存的修改。"
 msgid ""
 "A part of the image is selected: the pixels beneath the selection will be "
 "saved with a color you might not expect!"
-msgstr ""
+msgstr "已選擇部分影像：選擇區域中的像素會儲存為您不預期的色彩！"
 
 #. Context: the user tries to save the image while previewing an
 #. unapplied "transform" operation (scaling, cropping, whatever)
 #: src/saving_manager.py
 msgid "Modifications from the current tool haven't been applied."
-msgstr ""
+msgstr "還沒套用目前工具的修改。"
 
 #. To translators: this string should be quite short
 #: src/saving_manager.py
 msgid "Apply & save"
-msgstr ""
+msgstr "套用並儲存"
 
 #. To translators: this string should be quite short
 #: src/saving_manager.py
-#, fuzzy
 msgid "Deselect & save"
-msgstr "取消選擇"
+msgstr "取消選擇並儲存"
 
 #: src/saving_manager.py
-#, fuzzy
 msgid "Save anyway"
-msgstr "另存為"
+msgstr "無論如何都要儲存"
 
 #: src/saving_manager.py
-#, fuzzy
 msgid "Do you want to save anyway?"
-msgstr "您想在哪裡開啟 %s？"
+msgstr "您無論如何都要儲存嗎？"
 
 #. Context: confirm replacing transparent pixels with the selected color
 #: src/saving_manager.py
@@ -1451,11 +1426,11 @@ msgstr "將透明部分取代為："
 #. Context: an error message
 #: src/selection_manager.py
 msgid "The selection pixbuf is empty."
-msgstr ""
+msgstr "選擇的 Pixbuf 為空。"
 
 #: src/selection_manager.py
 msgid "The selection path is empty."
-msgstr ""
+msgstr "選擇的路徑為空。"
 
 #. Context: an error message
 #: src/tools_initializer.py
@@ -1469,24 +1444,23 @@ msgstr "啟動應用程式時發生錯誤。請向我們報告這個問題。"
 
 #: src/window.py
 msgid "The clipboard doesn't contain any image."
-msgstr ""
+msgstr "剪貼簿不包含影像。"
 
 #. Context: %s is a file name
 #: src/window.py
 #, python-format
 msgid "The file %s is already opened"
-msgstr ""
+msgstr "檔案 %s 已開啟"
 
 #. Context: the user would click here to confirm they want to open the
 #. same file twice
 #: src/window.py
-#, fuzzy
 msgid "Open again"
-msgstr "開啟檔案"
+msgstr "再次開啟"
 
 #: src/window.py
 msgid "Switch to this image"
-msgstr ""
+msgstr "切換到此影像"
 
 #: src/window.py
 msgid "Modifications will take effect in the next new window."
@@ -1494,18 +1468,17 @@ msgstr "修改將在下一個新視窗生效。"
 
 #: src/window.py
 msgid "Middle-click or press F8 to show/hide controls."
-msgstr ""
+msgstr "按滑鼠中鍵或按 F8 顯示/隱藏控制介面。"
 
 #: src/window.py
-#, fuzzy
 msgid "Press F11 to exit fullscreen."
-msgstr "結束全螢幕"
+msgstr "按 F11 結束全螢幕。"
 
 #: src/window.py
-#, fuzzy, python-format
+#, python-format
 msgid ""
 "Error loading the bottom pane for the tool '%s', please report this bug."
-msgstr "啟動應用程式時發生錯誤。請向我們報告這個問題。"
+msgstr "載入工具「%s」的底部窗格時發生錯誤，請報告程式錯誤。"
 
 #: src/window.py
 #, python-format
@@ -1540,9 +1513,8 @@ msgid "What do you want to do with %s?"
 msgstr "你想要對 %s 做什麼？"
 
 #: src/window.py
-#, fuzzy
 msgid "Image copied to clipboard"
-msgstr "在剪貼簿中編輯影像"
+msgstr "影像已複製到剪貼簿"
 
 #: src/window.py
 msgid "Import a picture"
@@ -1641,19 +1613,19 @@ msgid "BMP images"
 msgstr "BMP 影像"
 
 #: src/utilities/utilities_files.py
-#, fuzzy, python-format
+#, python-format
 msgid "%s isn't an image."
-msgstr "開啟影像"
+msgstr "%s 不是影像。"
 
 #: src/utilities/utilities_files.py
 msgid "Sorry, WEBP images can't be loaded by this app."
-msgstr ""
+msgstr "抱歉，本應用程式無法載入 WEBP 影像。"
 
 #. Context: an error message, %s is a file path
 #: src/utilities/utilities_files.py
 #, python-format
 msgid "Despite its name, %s is a WEBP file."
-msgstr ""
+msgstr "儘管名稱如此，%s 是 WEBP 檔案。"
 
 #: src/utilities/utilities_paths.py
 msgid "Continue"
@@ -1685,9 +1657,8 @@ msgstr "度"
 #. Context: this is equivalent to "Highlight: Light text on dark background"
 #. but it has to be FAR SHORTER so it fits in the color chooser
 #: src/optionsbars/classic/optionsbar_color_popover.py
-#, fuzzy
 msgid "Highlight (dark)"
-msgstr "螢光筆"
+msgstr "螢光筆（暗）"
 
 #: src/optionsbars/classic/optionsbar_color_popover.py
 #: src/tools/ui/tool-shape.ui
@@ -1725,15 +1696,13 @@ msgid "Palette"
 msgstr "調色板"
 
 #: src/optionsbars/selection/optionsbar-selection.ui
-#, fuzzy
 msgid "Selection options"
-msgstr "鉛筆選項"
+msgstr "選擇選項"
 
 #: src/optionsbars/selection/optionsbar-selection.ui src/tools/ui/selection.ui
 #: src/tools/ui/tool-eraser.ui
-#, fuzzy
 msgid "Replace with…"
-msgstr "擴展使用…"
+msgstr "取代為…"
 
 #: src/optionsbars/selection/optionsbar-selection.ui
 #: src/optionsbars/transform/optionsbar-crop.ui
@@ -1747,7 +1716,7 @@ msgstr "透明"
 
 #: src/optionsbars/selection/optionsbar-selection.ui src/tools/ui/selection.ui
 msgid "Extract from this color"
-msgstr ""
+msgstr "從此色彩擷取"
 
 #: src/optionsbars/transform/abstract-optionsbar-transform.ui
 msgid "More options"
@@ -1790,7 +1759,7 @@ msgstr "垂直翻轉"
 #. Context: the title of a menu to chose how the image will be scaled
 #: src/optionsbars/transform/optionsbar-scale.ui src/tools/ui/tool-scale.ui
 msgid "Keep proportions"
-msgstr "保持縱橫比"
+msgstr "保持寬高比"
 
 #. Context: an item in a menu whose title is "Keep proportions"
 #. Context for translations: "Always [keep proportions]"
@@ -1807,7 +1776,7 @@ msgstr "從角落縮放時"
 #. Context for translations: "[Keep proportions only] when setting values manually"
 #: src/optionsbars/transform/optionsbar-scale.ui src/tools/ui/tool-scale.ui
 msgid "When setting values manually"
-msgstr ""
+msgstr "手動設定數值時"
 
 #. Context: an item in a menu whose title is "Keep proportions"
 #. Context for translations: "Never [keep proportions]"
@@ -1816,12 +1785,10 @@ msgid "Never"
 msgstr "從不"
 
 #: src/optionsbars/transform/optionsbar-scale.ui src/tools/ui/tool-scale.ui
-#, fuzzy
 msgid "Pixels"
 msgstr "像素"
 
 #: src/optionsbars/transform/optionsbar-scale.ui src/tools/ui/tool-scale.ui
-#, fuzzy
 msgid "Percentage"
 msgstr "百分比"
 
@@ -1837,7 +1804,7 @@ msgstr "垂直變形"
 #: src/tools/abstract_tool.py
 #, python-brace-format
 msgid "Can't start operation: wrong tool id (expected {0}, got {1})"
-msgstr ""
+msgstr "無法開始操作：錯誤工具 id（預期 {0}，得到 {1}）"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
 #: src/tools/ui/tool-pencil.ui
@@ -1865,46 +1832,40 @@ msgstr "邊框"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
 #: src/tools/ui/tool-pencil.ui
-#, fuzzy
 msgid "No dashes"
-msgstr "使用虛線"
+msgstr "沒有虛線"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
 #: src/tools/ui/tool-pencil.ui
-#, fuzzy
 msgid "Simple dashes"
-msgstr "使用虛線"
+msgstr "簡單虛線"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
 #: src/tools/ui/tool-pencil.ui
-#, fuzzy
 msgid "Long dashes"
-msgstr "使用虛線"
+msgstr "長虛線"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
 #: src/tools/ui/tool-pencil.ui
-#, fuzzy
 msgid "Short dashes"
-msgstr "使用虛線"
+msgstr "短虛線"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
 #: src/tools/ui/tool-pencil.ui
 msgid "Alternated dashes"
-msgstr ""
+msgstr "交替虛線"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
-#, fuzzy
 msgid "No arrow"
-msgstr "箭頭"
+msgstr "沒有箭頭"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
 msgid "Simple arrow"
-msgstr ""
+msgstr "簡單箭頭"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-line.ui
-#, fuzzy
 msgid "Double arrow"
-msgstr "虛線箭頭"
+msgstr "雙箭頭"
 
 #: src/tools/ui/tool-arc.ui src/tools/ui/tool-brush.ui
 #: src/tools/ui/tool-highlight.ui src/tools/ui/tool-line.ui
@@ -1914,82 +1875,74 @@ msgid "Antialiasing"
 msgstr "反鋸齒"
 
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_simple.py
-#, fuzzy
 msgid "Simple brush"
-msgstr "使用虛線"
+msgstr "簡單筆刷"
 
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_airbrush.py
 msgid "Airbrush"
-msgstr ""
+msgstr "噴槍"
 
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_hairy.py
-#, fuzzy
 msgid "Hairy brush"
-msgstr "使用虛線"
+msgstr "毛狀筆刷"
 
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_nib.py
 msgid "Calligraphic nib"
-msgstr ""
+msgstr "書法尖"
 
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_nib.py
 msgid "Right-handed nib"
-msgstr ""
+msgstr "右斜尖"
 
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_nib.py
-#, fuzzy
 msgid "Vertical nib"
-msgstr "垂直"
+msgstr "垂直尖"
 
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_nib.py
 msgid "Left-handed nib"
-msgstr ""
+msgstr "左斜尖"
 
 #. brush_direction == 'horizontal':
 #: src/tools/ui/tool-brush.ui src/tools/classic_tools/brushes/brush_nib.py
-#, fuzzy
 msgid "Horizontal nib"
-msgstr "水平"
+msgstr "水平尖"
 
 #: src/tools/ui/tool-eraser.ui src/tools/classic_tools/erasers/eraser_rubber.py
 msgid "Rubber eraser"
-msgstr ""
+msgstr "橡皮擦"
 
 #: src/tools/ui/tool-eraser.ui src/tools/classic_tools/erasers/eraser_area.py
-#, fuzzy
 msgid "Rectangle area"
-msgstr "矩形"
+msgstr "矩形區域"
 
 #. Context: this feature erases the color where the user clicked.
 #. For example to cut out an object from its solid background.
 #: src/tools/ui/tool-eraser.ui src/tools/classic_tools/erasers/eraser_color.py
-#, fuzzy
 msgid "Remove color"
-msgstr "原始來源的色彩"
+msgstr "移除色彩"
 
 #: src/tools/ui/tool-eraser.ui src/tools/classic_tools/erasers/eraser_area.py
 msgid "Blur"
 msgstr "模糊"
 
 #: src/tools/ui/tool-eraser.ui src/tools/classic_tools/erasers/eraser_area.py
-#, fuzzy
 msgid "Shuffle pixels"
-msgstr "像素"
+msgstr "隨機像素"
 
 #: src/tools/ui/tool-eraser.ui src/tools/classic_tools/erasers/eraser_area.py
 msgid "Shuffle and blur"
-msgstr ""
+msgstr "隨機與模糊"
 
 #. Context: a filter to censor the image with some little tiles
 #: src/tools/ui/tool-eraser.ui src/tools/ui/tool-filters.ui
 #: src/tools/classic_tools/erasers/eraser_area.py
 #: src/tools/transform_tools/tool_filters.py
 msgid "Mosaic"
-msgstr ""
+msgstr "馬賽克"
 
 #: src/tools/ui/tool-eraser.ui
-#, fuzzy
 msgid "Solid color"
-msgstr "副色彩"
+msgstr "單一色彩"
 
 #: src/tools/ui/tool-filters.ui src/tools/transform_tools/tool_filters.py
 msgid "Change saturation"
@@ -2008,7 +1961,7 @@ msgstr "增加透明度"
 #: src/tools/ui/tool-filters.ui src/tools/transform_tools/tool_filters.py
 #: src/tools/transform_tools/filters/filter_contrast.py
 msgid "Increase contrast"
-msgstr ""
+msgstr "增加對比"
 
 #. Context: the title of the menu with various types of blurring
 #. filters and their options.
@@ -2034,32 +1987,28 @@ msgid "No direction"
 msgstr "無方向"
 
 #: src/tools/ui/tool-filters.ui
-#, fuzzy
 msgid "Blur horizontally"
-msgstr "水平翻轉"
+msgstr "水平模糊"
 
 #: src/tools/ui/tool-filters.ui
-#, fuzzy
 msgid "Blur vertically"
-msgstr "垂直翻轉"
+msgstr "垂直模糊"
 
 #: src/tools/ui/tool-filters.ui src/tools/transform_tools/tool_filters.py
 msgid "Invert colors"
 msgstr "反轉色彩"
 
 #: src/tools/ui/tool-highlight.ui
-#, fuzzy
 msgid "Straighten the line"
-msgstr "縮放選擇區域"
+msgstr "拉直線條"
 
 #: src/tools/ui/tool-line.ui
 msgid "Color gradient"
 msgstr "色彩漸層"
 
 #: src/tools/ui/tool-line.ui
-#, fuzzy
 msgid "Locked direction"
-msgstr "無方向"
+msgstr "鎖定方向"
 
 #. Context: title for the list of the possible painting algorithms.
 #: src/tools/ui/tool-paint.ui
@@ -2085,13 +2034,12 @@ msgstr "擦除並取代"
 #. paints over the entire image, instead of following the shapes
 #. already drawn.
 #: src/tools/ui/tool-paint.ui
-#, fuzzy
 msgid "Entire image"
-msgstr "已開啟的影像"
+msgstr "整個影像"
 
 #: src/tools/ui/tool-points.ui
 msgid "Dots type"
-msgstr ""
+msgstr "點類型"
 
 #: src/tools/ui/tool-points.ui src/tools/ui/tool-shape.ui
 #: src/tools/classic_tools/tool_points.py src/tools/classic_tools/tool_shape.py
@@ -2100,31 +2048,31 @@ msgstr "圓"
 
 #: src/tools/ui/tool-points.ui src/tools/classic_tools/tool_points.py
 msgid "Cross"
-msgstr ""
+msgstr "十字"
 
 #: src/tools/ui/tool-points.ui src/tools/classic_tools/tool_points.py
 msgid "X-shaped cross"
-msgstr ""
+msgstr "X 形"
 
 #: src/tools/ui/tool-points.ui
 msgid "Include a number"
-msgstr ""
+msgstr "包含數字"
 
 #: src/tools/ui/tool-points.ui
 msgid "Next number"
-msgstr ""
+msgstr "下一個數字"
 
 #: src/tools/ui/tool-points.ui
 msgid "Reset number"
-msgstr ""
+msgstr "重設數字"
 
 #: src/tools/ui/tool-points.ui
 msgid "Decrement number"
-msgstr ""
+msgstr "減小數字"
 
 #: src/tools/ui/tool-points.ui
 msgid "Increment number"
-msgstr ""
+msgstr "增大數字"
 
 #: src/tools/ui/tool-shape.ui src/tools/classic_tools/tool_shape.py
 msgid "Solid outline"
@@ -2219,15 +2167,13 @@ msgstr "陰影"
 
 #. Context: a type of background behind the inserted text
 #: src/tools/ui/tool-text.ui src/tools/classic_tools/tool_text.py
-#, fuzzy
 msgid "Thin outline"
-msgstr "無輪廓"
+msgstr "細外框"
 
 #. Context: a type of background behind the inserted text
 #: src/tools/ui/tool-text.ui src/tools/classic_tools/tool_text.py
-#, fuzzy
 msgid "Thick outline"
-msgstr "無輪廓"
+msgstr "粗外框"
 
 #. Context: a type of background behind the inserted text
 #: src/tools/ui/tool-text.ui src/tools/classic_tools/tool_text.py
@@ -2244,7 +2190,7 @@ msgstr "曲線選項"
 
 #: src/tools/classic_tools/tool_arc.py
 msgid "Draw a second segment to complete the curve"
-msgstr ""
+msgstr "畫出第二段完成曲線"
 
 #: src/tools/classic_tools/tool_arc.py src/tools/classic_tools/tool_line.py
 msgid "Dashed arrow"
@@ -2262,38 +2208,35 @@ msgstr "虛線"
 #: src/tools/classic_tools/tool_arc.py src/tools/classic_tools/tool_line.py
 #: src/tools/classic_tools/tool_pencil.py
 msgid "Press <Alt> to toggle the 'outline' option"
-msgstr ""
+msgstr "按 <Alt> 切換「邊框」選項"
 
 #: src/tools/classic_tools/tool_brush.py
-#, fuzzy
 msgid "Brush options"
-msgstr "更多選項"
+msgstr "筆刷選項"
 
 #: src/tools/classic_tools/tool_eraser.py
 msgid "Press <Shift> to erase a path instead"
-msgstr ""
+msgstr "按 <Shift> 改為擦除路徑"
 
 #: src/tools/classic_tools/tool_eraser.py
 msgid "Press <Shift> to erase a rectangle area instead"
-msgstr ""
+msgstr "按 <Shift> 改為擦除矩形區域"
 
 #: src/tools/classic_tools/tool_eraser.py
-#, fuzzy
 msgid "Eraser options"
-msgstr "更多選項"
+msgstr "橡皮擦選項"
 
 #: src/tools/classic_tools/tool_highlight.py
 msgid "Press <Shift> to temporarily highlight on dark background instead"
-msgstr ""
+msgstr "按 <Shift> 暫時改為在深色背景標記"
 
 #: src/tools/classic_tools/tool_highlight.py
 msgid "Press <Shift> to temporarily highlight on light background instead"
-msgstr ""
+msgstr "按 <Shift> 暫時改為在淺色背景標記"
 
 #: src/tools/classic_tools/tool_highlight.py
-#, fuzzy
 msgid "Highlighter options"
-msgstr "螢光筆"
+msgstr "螢光筆選項"
 
 #: src/tools/classic_tools/tool_line.py
 msgid "Line"
@@ -2301,20 +2244,20 @@ msgstr "直線"
 
 #: src/tools/classic_tools/tool_line.py src/tools/classic_tools/tool_shape.py
 #: src/tools/selection_tools/select_rect.py
-#, fuzzy, python-format
+#, python-format
 msgid "Width: %spx"
-msgstr "寬度"
+msgstr "寬度：%spx"
 
 #: src/tools/classic_tools/tool_line.py src/tools/classic_tools/tool_shape.py
 #: src/tools/selection_tools/select_rect.py
-#, fuzzy, python-format
+#, python-format
 msgid "Height: %spx"
-msgstr "高度"
+msgstr "高度：%spx"
 
 #: src/tools/classic_tools/tool_line.py
 #, python-format
 msgid "Length: %spx"
-msgstr ""
+msgstr "長度：%spx"
 
 #: src/tools/classic_tools/tool_line.py
 msgid "Line options"
@@ -2322,34 +2265,33 @@ msgstr "直線選項"
 
 #: src/tools/classic_tools/tool_line.py
 msgid "Press <Shift> to unlock the line direction"
-msgstr ""
+msgstr "按 <Shift> 解除鎖定直線方向"
 
 #: src/tools/classic_tools/tool_line.py
 msgid "Press <Shift> to lock the line direction"
-msgstr ""
+msgstr "按 <Shift> 鎖定直線方向"
 
 #: src/tools/classic_tools/tool_paint.py
 msgid "Painting options"
-msgstr "繪畫選項"
+msgstr "填色選項"
 
 #: src/tools/classic_tools/tool_paint.py
 msgid "Click on an area to replace its color by transparency"
 msgstr "點選一個區域以用透明色取代其色彩"
 
 #: src/tools/classic_tools/tool_paint.py
-#, fuzzy
 msgid "Click on the canvas to entirely paint it"
-msgstr "點選形狀的第一個節點以將其關閉。"
+msgstr "在畫布上按一下，將其完全填色"
 
 #: src/tools/classic_tools/tool_paint.py
 #: src/tools/selection_tools/select_color.py
 msgid "May not work for complex shapes"
-msgstr ""
+msgstr "可能無法用於複雜形狀"
 
 #: src/tools/classic_tools/tool_paint.py
 #: src/tools/selection_tools/select_color.py
 msgid "It will not work well if the area's edges are blurry"
-msgstr ""
+msgstr "如果區域邊緣模糊，效果會不好"
 
 #: src/tools/classic_tools/tool_pencil.py
 msgid "Pencil"
@@ -2360,26 +2302,23 @@ msgid "Pencil options"
 msgstr "鉛筆選項"
 
 #: src/tools/classic_tools/tool_points.py
-#, fuzzy
 msgid "Points options"
-msgstr "字型選項"
+msgstr "點選項"
 
 #: src/tools/classic_tools/tool_points.py
 #, python-format
 msgid "Next number: %s"
-msgstr ""
+msgstr "下一個數字：%s"
 
 #. Context: fill a shape with the color of the left click
 #: src/tools/classic_tools/tool_shape.py
-#, fuzzy
 msgid "Filled with main color"
-msgstr "編輯主色彩…"
+msgstr "以主色彩填充"
 
 #. Context: fill a shape with the color of the right click
 #: src/tools/classic_tools/tool_shape.py
-#, fuzzy
 msgid "Filled with secondary color"
-msgstr "編輯副色彩…"
+msgstr "以副色彩填充"
 
 #: src/tools/classic_tools/tool_shape.py
 msgid "Shape"
@@ -2388,7 +2327,7 @@ msgstr "形狀"
 #: src/tools/classic_tools/tool_shape.py
 #, python-format
 msgid "Radius: %spx"
-msgstr ""
+msgstr "半徑：%spx"
 
 #: src/tools/classic_tools/tool_shape.py
 msgid "Shape options"
@@ -2401,7 +2340,7 @@ msgstr "點選形狀的第一個節點以將其關閉。"
 
 #: src/tools/classic_tools/tool_shape.py
 msgid "Press <Alt>, <Shift>, or both, to quickly change the 'filling' option"
-msgstr ""
+msgstr "按 <Alt>、<Shift> 或兩者都按，快速變更填充選項"
 
 #: src/tools/classic_tools/tool_text.py
 msgid "Text"
@@ -2413,33 +2352,33 @@ msgstr "字型選項"
 
 #: src/tools/classic_tools/tool_text.py
 msgid "Grab the rectangle to adjust the text position"
-msgstr ""
+msgstr "抓取矩形調整文字位置"
 
 #: src/tools/classic_tools/tool_text.py
 msgid "Click outside the rectangle to apply"
-msgstr ""
+msgstr "在矩形外按一下以套用"
 
 #: src/tools/classic_tools/brushes/brush_airbrush.py
 msgid "Density depends on the stylus pressure"
-msgstr ""
+msgstr "密度取決於數位筆壓力"
 
 #: src/tools/classic_tools/brushes/brush_airbrush.py
 msgid "Density depends on the mouse speed"
-msgstr ""
+msgstr "密度取決於滑鼠速度"
 
 #: src/tools/classic_tools/brushes/brush_hairy.py
 #: src/tools/classic_tools/brushes/brush_nib.py
 #: src/tools/classic_tools/brushes/brush_simple.py
 msgid "Width depends on the stylus pressure"
-msgstr ""
+msgstr "寬度取決於數位筆壓力"
 
 #: src/tools/classic_tools/brushes/brush_nib.py
 msgid "Width depends on the line orientation"
-msgstr ""
+msgstr "寬度取決於直線方向"
 
 #: src/tools/classic_tools/brushes/brush_simple.py
 msgid "Width depends on the mouse speed"
-msgstr ""
+msgstr "寬度取決於滑鼠速度"
 
 #: src/tools/selection_tools/abstract_select.py
 msgid "Drag the selection or right-click on the canvas"
@@ -2460,40 +2399,37 @@ msgstr "錯誤：數值無效"
 #. The options of the "crop" tool are all about how to expand the canvas,
 #. hence this label.
 #: src/tools/transform_tools/tool_crop.py
-#, fuzzy
 msgid "Expanding options"
-msgstr "繪畫選項"
+msgstr "擴展選項"
 
 #: src/tools/transform_tools/tool_crop.py
 msgid "The sides you'll crop are hinted by the mouse pointer"
-msgstr ""
+msgstr "滑鼠指標會指示裁切的邊"
 
 #: src/tools/transform_tools/tool_crop.py
 msgid "Cropping the selection"
 msgstr "裁切選擇區域"
 
 #: src/tools/transform_tools/tool_crop.py
-#, fuzzy
 msgid "Cropping or expanding the canvas"
-msgstr "裁切畫布"
+msgstr "裁切或擴展畫布"
 
 #: src/tools/transform_tools/tool_crop.py
 #: src/tools/transform_tools/tool_rotate.py
 #: src/tools/transform_tools/tool_scale.py
 #: src/tools/transform_tools/tool_skew.py
 msgid "Don't forget to confirm the operation!"
-msgstr ""
+msgstr "別忘了確認操作！"
 
 #: src/tools/transform_tools/tool_crop.py
 #: src/tools/transform_tools/tool_skew.py
 msgid ""
 "Press <Alt>, <Shift>, or both, to quickly change the 'expand with' option"
-msgstr ""
+msgstr "按 <Alt>、<Shift> 或兩者都按，快速變更「擴展使用」選項"
 
 #: src/tools/transform_tools/tool_filters.py
-#, fuzzy
 msgid "Active filter"
-msgstr "其他工具"
+msgstr "使用中的濾鏡"
 
 #: src/tools/transform_tools/tool_filters.py
 msgid "Click on the image to preview the selected filter"
@@ -2502,12 +2438,11 @@ msgstr "點選影像以預覽選擇的濾鏡"
 #. Context: a filter. See "image embossing" on wikipedia
 #: src/tools/transform_tools/tool_filters.py
 msgid "Emboss"
-msgstr ""
+msgstr "浮雕"
 
 #: src/tools/transform_tools/tool_rotate.py
-#, fuzzy
 msgid "Rotating options"
-msgstr "繪畫選項"
+msgstr "旋轉選項"
 
 #: src/tools/transform_tools/tool_rotate.py
 msgid "Rotating the selection"
@@ -2518,9 +2453,8 @@ msgid "Rotating the canvas"
 msgstr "旋轉畫布"
 
 #: src/tools/transform_tools/tool_scale.py
-#, fuzzy
 msgid "Scaling options"
-msgstr "繪畫選項"
+msgstr "縮放選項"
 
 #: src/tools/transform_tools/tool_scale.py
 msgid "Scaling the selection"
@@ -2532,26 +2466,23 @@ msgstr "縮放畫布"
 
 #: src/tools/transform_tools/tool_scale.py
 msgid "Press <Shift> to quickly toggle the 'lock proportions' option"
-msgstr ""
+msgstr "按 <Shift> 快速切換「鎖定寬高比」選項"
 
 #: src/tools/transform_tools/tool_skew.py
-#, fuzzy
 msgid "Skewing options"
-msgstr "繪畫選項"
+msgstr "扭曲選項"
 
 #: src/tools/transform_tools/tool_skew.py
 msgid "The directions of the deformation are hinted by the mouse pointer"
-msgstr ""
+msgstr "滑鼠指標會指示變形方向"
 
 #: src/tools/transform_tools/tool_skew.py
-#, fuzzy
 msgid "Skewing the selection"
-msgstr "縮放選擇區域"
+msgstr "扭曲選擇區域"
 
 #: src/tools/transform_tools/tool_skew.py
-#, fuzzy
 msgid "Skewing the canvas"
-msgstr "縮放畫布"
+msgstr "扭曲畫布"
 
 #: src/tools/transform_tools/filters/filter_blur.py
 msgid "Blur radius"
@@ -2561,14 +2492,3 @@ msgstr "模糊半徑"
 msgid "Saturation"
 msgstr "飽和度"
 
-#~ msgid "Horizontal"
-#~ msgstr "水平"
-
-#~ msgid "Vertical"
-#~ msgstr "垂直"
-
-#~ msgid "A drawing application for the GNOME desktop"
-#~ msgstr "為 GNOME 桌面環境打造的繪圖應用程式"
-
-#~ msgid "Quit"
-#~ msgstr "結束"


### PR DESCRIPTION
### appdata: Add categories and keywords support

These tags may improve Software Center accessibility.

More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-categories

### appdata: Use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### data: Update runtime version

appstreamcli available on GNOME 45 runtime.

