### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/data/com.github.maoschanz.drawing.appdata.xml.in
+++ b/data/com.github.maoschanz.drawing.appdata.xml.in
@@ -33,17 +33,6 @@
     <p>Supported file types include PNG, JPEG and BMP.</p>
   </description>
 
-  <categories>
-    <category>Graphics</category>
-  </categories>
-  
-  <keywords>
-    <keyword translate="no">drawing</keyword>
-    <keyword>Paint</keyword>
-    <keyword>Sketch</keyword>
-    <keyword>Pencil</keyword>
-  </keywords>
-  
   <releases>
     <release version="1.2.0" date="2023-04-29">
     <!-- TODO actual date -->

--- a/data/com.github.maoschanz.drawing.appdata.xml.in
+++ b/data/com.github.maoschanz.drawing.appdata.xml.in
@@ -157,7 +157,11 @@
     </release>
   </releases>
 
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Romain F. T.</developer_name>
+  <developer id="github.com">
+    <name translatable="no">Romain F. T.</name>
+  </developer>
   <update_contact>rrroschan@gmail.com</update_contact>
   <url type="homepage">https://maoschanz.github.io/drawing</url>
   <url type="bugtracker">https://github.com/maoschanz/drawing/issues</url>

--- a/data/meson.build
+++ b/data/meson.build
@@ -43,7 +43,8 @@ if get_option('enable-translations-and-appdata')
 		test(
 			'Validate appstream file',
 			appstreamcli,
-			args: ['validate', '--no-net', appstream_file]
+			args: ['validate', '--no-net', '--explain', appstream_file],
+			workdir: meson.current_build_dir()
 		)
 	endif
 endif


### PR DESCRIPTION
appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli arguments

### appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories

