### PR TITLE
Window: remember size

### DIFF
--- a/data/com.github.maoschanz.drawing.gschema.xml
+++ b/data/com.github.maoschanz.drawing.gschema.xml
@@ -89,10 +89,20 @@
     </key>
 
     <!-- Remembered state of the window -->
+    <key type="i" name="window-width">
+      <default>1000</default>
+      <summary>Width of the window</summary>
+      <description>The width of the last closed window.</description>
+    </key>
+    <key type="i" name="window-height">
+      <default>600</default>
+      <summary>Height of the window</summary>
+      <description>The height of the last closed window.</description>
+    </key>
     <key type="b" name="maximized">
       <default>false</default>
-      <summary>State of the window</summary>
-      <description>The state of the last closed window.</description>
+      <summary>Maximization of the window</summary>
+      <description>The maximization state of the last closed window.</description>
     </key>
     <key type="b" name="show-labels">
       <default>false</default>

--- a/src/window.py
+++ b/src/window.py
@@ -72,6 +72,7 @@ class DrWindow(Gtk.ApplicationWindow):
 		self.devel_mode = False
 		self.should_track_framerate = False
 
+		self.resize(self.gsettings.get_int("window-width"), self.gsettings.get_int("window-height"))
 		if self.gsettings.get_boolean('maximized'):
 			self.maximize()
 
@@ -384,6 +385,8 @@ class DrWindow(Gtk.ApplicationWindow):
 		self._decorations.remove_from_ui()
 		self.options_manager.persist_tools_options()
 		self.gsettings.set_string('last-active-tool', self.active_tool_id)
+		self.gsettings.set_int("window-width", self.get_size().width)
+		self.gsettings.set_int("window-height", self.get_size().height)
 		self.gsettings.set_boolean('maximized', self.is_maximized())
 		return False
 


### PR DESCRIPTION
If the user sets the window dimensions to be less than the canvas size loaded on startup, the window will ignore the canvas size and go with the window size set by the user. I can change this if that behavior isn't desired.

Closes #634