### PR TITLE
Main: change bug report link

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -35,7 +35,7 @@ class Application(Gtk.Application):
 
 	APP_ID = 'com.github.maoschanz.drawing'
 	APP_PATH = '/com/github/maoschanz/drawing'
-	BUG_REPORT_URL = 'https://github.com/maoschanz/drawing/issues/new/choose'
+	BUG_REPORT_URL = 'https://github.com/maoschanz/drawing/issues'
 	FLATPAK_BINARY_PATH = '/app/bin/drawing'
 	CURRENT_BINARY_PATH = ''
 
@@ -227,7 +227,7 @@ class Application(Gtk.Application):
 		return self.open_window_with_content(None)
 
 	def on_report(self, *args):
-		"""Action callback, opening a new issue on the github repo."""
+		"""Action callback, opening a page to the Github issue tracker."""
 		win = self.props.active_window
 		Gtk.show_uri_on_window(win, self.BUG_REPORT_URL, Gdk.CURRENT_TIME)
 


### PR DESCRIPTION
I changed the link from the new issue page to the issue tracker. This means that users can see if the issue has already been reported, and won't be immediately sent to a sign in page if they aren't signed into GitHub. I've seen other GNOME apps do this, so that's why I chose to send users to that.

Closes #641