### PR TITLE
Increase new image size limit

### DIFF
--- a/src/ui/new-image-dialog.ui
+++ b/src/ui/new-image-dialog.ui
@@ -3,7 +3,7 @@
 
   <object class="GtkAdjustment" id="adj_width">
     <property name="lower">1</property>
-    <property name="upper">4096</property>
+    <property name="upper">9999</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
     <property name="value">10</property>
@@ -11,7 +11,7 @@
 
   <object class="GtkAdjustment" id="adj_height">
     <property name="lower">1</property>
-    <property name="upper">4096</property>
+    <property name="upper">9999</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
     <property name="value">10</property>

--- a/src/ui/preferences.ui
+++ b/src/ui/preferences.ui
@@ -3,7 +3,7 @@
 
   <object class="GtkAdjustment" id="adj_width">
     <property name="lower">1</property>
-    <property name="upper">4096</property>
+    <property name="upper">9999</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
     <property name="value">10</property>
@@ -11,7 +11,7 @@
 
   <object class="GtkAdjustment" id="adj_height">
     <property name="lower">1</property>
-    <property name="upper">4096</property>
+    <property name="upper">9999</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
     <property name="value">10</property>


### PR DESCRIPTION
Increases the new image size limit from 4096 pixels to 9999 pixels. Hopefully that amount is good for now. If the limit is theoretically eventually removed, then I'm not sure how that would be done using GtkAdjustments, because as far as I know, they require an upper limit.

Closes #608