### PR TITLE
Update to new Flathub badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It should also be compatible with the *Pinephone* and *Librem 5*
 You can install it from flathub.org using the instructions on
 [this page](https://flathub.org/apps/details/com.github.maoschanz.drawing).
 
-[<img alt="" height="100" src="https://flathub.org/assets/badges/flathub-badge-en.png">](https://flathub.org/apps/details/com.github.maoschanz.drawing).
+[<img alt="" height="100" src="https://flathub.org/api/badge?locale=en">](https://flathub.org/apps/details/com.github.maoschanz.drawing).
 
 ### Other packages available
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It should also be compatible with the *Pinephone* and *Librem 5*
 You can install it from flathub.org using the instructions on
 [this page](https://flathub.org/apps/details/com.github.maoschanz.drawing).
 
-[<img alt="" height="100" src="https://flathub.org/api/badge?locale=en">](https://flathub.org/apps/details/com.github.maoschanz.drawing).
+[<img alt="Get it on Flathub" src="https://flathub.org/api/badge?locale=en">](https://flathub.org/apps/details/com.github.maoschanz.drawing).
 
 ### Other packages available
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -117,7 +117,7 @@
           <a itemprop="downloadUrl"
              href="https://flathub.org/apps/details/com.github.maoschanz.drawing"
              class="limited-image">
-            <img src="https://flathub.org/assets/badges/flathub-badge-en.png"
+            <img src="https://flathub.org/api/badge?locale=en"
                  class="limited-image"
                  alt="Install it from Flathub"
                  title="Install it from Flathub" />


### PR DESCRIPTION
Updates the README to use the new [Flathub badge](https://flathub.org/badges). I updated it to use the default width, since the badge looked blurry with the forced width. I did it in separate commits, so it should be easy enough to drop if you disagree.