### PR TITLE
Fixes eu.po syntax error

### DIFF
--- a/po/eu.po
+++ b/po/eu.po
@@ -103,18 +103,18 @@ msgid ""
 "A former option of the paint bucket tool, which didn't belong there, has "
 "been improved and moved to the eraser tool."
 msgstr "Pintura-ontzi tresnaren lehen aukera batek, ez zegokiona,"
-"hobetu eta borragoma tresnara eraman da".
+"hobetu eta borragoma tresnara eraman da."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""
 "Transparency is henceforth correctly preserved when the \"skew\" tool "
 "expands the canvas with a solid color."
 msgstr "Gardentasuna behar bezala gordeko da aurrerantzean \" okertu \" tresna "
-"kolore solido batekin ohiala zabaltzen du".
+"kolore solido batekin ohiala zabaltzen du."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid "You can now adjust the position of the canvas when you're cropping it."
-msgstr "Orain ohialaren posizioa doitu dezakezu mozten duzunean".
+msgstr "Orain ohialaren posizioa doitu dezakezu mozten duzunean."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""
@@ -148,7 +148,7 @@ msgid ""
 "shortcuts to change tab."
 msgstr ""
 "\"hautatu\" tresnaren erabiltzailearen interfazea aldatu da, baita ere "
-"fitxa aldatzeko lasterbideak".
+"fitxa aldatzeko lasterbideak."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""
@@ -171,7 +171,7 @@ msgid ""
 "the message dialog to warn you about the release notes is less intrusive."
 msgstr ""
 "Komunitatearen eskaeraren arabera, \"nabarmendu\" tresna lehenespenez gaituta dago orain, eta "
-"argitalpen-oharrei buruz ohartarazteko mezuen elkarrizketa-koadroa ez da hain intrusiboa".
+"argitalpen-oharrei buruz ohartarazteko mezuen elkarrizketa-koadroa ez da hain intrusiboa."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""
@@ -193,7 +193,7 @@ msgid ""
 "sandbox has also been fixed."
 msgstr ""
 "Komando-lerroaren analisia okerra aplikazioa flatpaketik kanpo erabiltzean"
-"hondar-kutxa ere konpondu da".
+"hondar-kutxa ere konpondu da."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""
@@ -201,7 +201,7 @@ msgid ""
 "been mended too."
 msgstr ""
 "Elementary OS duten erabiltzaileentzat, leihoen tamaina aldatzeari buruzko arazo txiki bat"
-"ere konponduta".
+"ere konponduta."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""
@@ -235,8 +235,8 @@ msgid ""
 "Zooming very deep is now possible, and the rendering will be very crisp, "
 "even at 2000%%."
 msgstr ""
-"Orain zoom oso sakona egitea posible da, eta errendatzea oso kurruskaria izango da".
-"%2000ean ere".
+"Orain zoom oso sakona egitea posible da, eta errendatzea oso kurruskaria izango da."
+"%2000ean ere."
 
 #: data/com.github.maoschanz.drawing.appdata.xml.in
 msgid ""


### PR DESCRIPTION
- There were syntax error in several lines of code in `eu.po`.
- The errors were all caused by the full stop after the string literal.
- The fixes moved the full stop back inside the string literal quotations.