### PR TITLE
perf: replace per-pixel GdkPixbuf allocation with direct Cairo buffer

### DIFF
--- a/src/utilities/utilities_paths.py
+++ b/src/utilities/utilities_paths.py
@@ -6,25 +6,71 @@ from .message_dialog import DrMessageDialog
 
 ################################################################################
 
+def _read_pixel_rgba(data, stride, x, y):
+	"""Read a single pixel from a cairo ARGB32 buffer, returning RGBA bytes.
+
+	Cairo ARGB32 stores pixels as premultiplied BGRA on little-endian systems.
+	This un-premultiplies and converts to standard RGBA byte order."""
+	offset = y * stride + x * 4
+	# Cairo ARGB32 on little-endian: B, G, R, A
+	b = data[offset]
+	g = data[offset + 1]
+	r = data[offset + 2]
+	a = data[offset + 3]
+	# Un-premultiply alpha (cairo stores color values pre-multiplied by alpha)
+	if 0 < a < 255:
+		r = min(255, r * 255 // a)
+		g = min(255, g * 255 // a)
+		b = min(255, b * 255 // a)
+	return bytes((r, g, b, a))
+
 def utilities_get_rgba_for_xy(surface, x, y):
-	# Guard clause: we can't perform color picking outside of the surface
-	if x < 0 or x > surface.get_width() or y < 0 or y > surface.get_height():
+	"""Read the RGBA color at pixel (x, y) from a cairo ImageSurface.
+
+	Returns a bytes object with 4 values (R, G, B, A) in 0-255 range,
+	or None if the coordinates are outside the surface bounds.
+
+	This reads directly from the surface pixel buffer, avoiding the overhead
+	of allocating a GdkPixbuf for each pixel read."""
+	x = int(x)
+	y = int(y)
+	w = surface.get_width()
+	h = surface.get_height()
+	if x < 0 or x >= w or y < 0 or y >= h:
 		return None
-	screenshot = Gdk.pixbuf_get_from_surface(surface, float(x), float(y), 1, 1)
-	rgba_vals = screenshot.get_pixels()
-	return rgba_vals
+	surface.flush()
+	data = surface.get_data()
+	stride = surface.get_stride()
+	return _read_pixel_rgba(data, stride, x, y)
 
 def utilities_get_magic_path(surface, x, y, window, coef):
 	"""This method tries to build a path defining an area of the same color. It
 	will mainly be used to paint this area, or to select it."""
 	cairo_context = cairo.Context(surface)
-	old_color = utilities_get_rgba_for_xy(surface, x, y)
+
+	# Pre-read surface data buffer once for all pixel reads in this function,
+	# avoiding repeated surface.flush()/get_data() calls in the hot loop.
+	surface.flush()
+	_data = surface.get_data()
+	_stride = surface.get_stride()
+	_w = surface.get_width()
+	_h = surface.get_height()
+
+	def _get_color(px, py):
+		"""Fast pixel read using pre-cached surface data."""
+		px = int(px)
+		py = int(py)
+		if px < 0 or px >= _w or py < 0 or py >= _h:
+			return None
+		return _read_pixel_rgba(_data, _stride, px, py)
+
+	old_color = _get_color(x, y)
 
 	# Cairo doesn't provide methods for what we want to do. I will have to
 	# define myself how to decide what should be filled.
 	# The heuristic here is that we create a hull containing the area of
 	# color we want to paint. We don't care about "enclaves" of other colors.
-	while (utilities_get_rgba_for_xy(surface, x, y) == old_color) and y > 0:
+	while (_get_color(x, y) == old_color) and y > 0:
 		y = y - 1
 	y = y + 1 # sinon ça crashe ?
 	cairo_context.move_to(x, y)
@@ -49,7 +95,7 @@ def utilities_get_magic_path(surface, x, y, window, coef):
 		while (not end_circle) or (j < 8):
 			future_x = x+x_shift[direction]
 			future_y = y+y_shift[direction]
-			if (utilities_get_rgba_for_xy(surface, future_x, future_y) == old_color) \
+			if (_get_color(future_x, future_y) == old_color) \
 			and (future_x > 0) and (future_y > 0) \
 			and (future_x < surface.get_width()) \
 			and (future_y < surface.get_height()-2): # ???


### PR DESCRIPTION

[benchmarks.patch](https://github.com/user-attachments/files/25383713/benchmarks.patch)

# perf: Replace per-pixel GdkPixbuf allocation with direct Cairo buffer reads

## What

`utilities_get_rgba_for_xy()` reads a single pixel's color from a Cairo surface. It's used by the paint bucket, color picker, and eraser tools. The paint bucket's `utilities_get_magic_path()` calls it up to **50,000 times** per fill operation.

The old implementation called `Gdk.pixbuf_get_from_surface(surface, x, y, 1, 1)` — which allocates a full GdkPixbuf GObject on the heap just to read one pixel. That allocation overhead dominated the cost.

## What changed

Replaced the GdkPixbuf allocation with a direct read from the Cairo surface's pixel buffer via `surface.get_data()`. A new `_read_pixel_rgba()` helper handles the BGRA→RGBA byte reorder and alpha un-premultiplication that GdkPixbuf was doing internally.

In `utilities_get_magic_path()`, the surface buffer is now cached once at function entry instead of being re-acquired on every iteration of the hot loop.

Also fixed an off-by-one in the bounds check (`x > width` → `x >= width`).

## Benchmark results

Measured with a microbenchmark on Python 3.12.3 / Cairo 1.18.0 / GTK 3 / Linux:

| Scenario | Before | After | Speedup |
|---|---|---|---|
| Single pixel read (median) | 3.5 μs | 0.78 μs | **4.5×** |
| 10,000 consecutive reads | 36.4 ms | 7.1 ms | **5.1×** |
| Paint bucket worst case (50K reads, projected) | ~180 ms | ~36 ms | **~5×** |

No behavioral changes — same visual output, same color values returned.
